### PR TITLE
[femutils] Use all available cores for the linear system solver

### DIFF
--- a/femutils/AlephDoFLinearSystem.cc
+++ b/femutils/AlephDoFLinearSystem.cc
@@ -154,7 +154,10 @@ class AlephDoFLinearSystemImpl
     // TODO: Linear algebra backend should be accessed from arc file.
     if (!m_aleph_kernel){
       info() << "Creating Aleph Kernel";
-      m_aleph_kernel = new AlephKernel(m_sub_domain, solver_backend, 1);
+      // We can use less than the number of MPI ranks
+      // but for the moment we use all the available cores.
+      Int32 nb_core = m_sub_domain->parallelMng()->commSize();
+      m_aleph_kernel = new AlephKernel(m_sub_domain, solver_backend, nb_core);
     }
     else{
       //


### PR DESCRIPTION
Before that we only used one core.

And example simulation of Poisson with 4 cores repots the following in `-ksp_view`

```
  Mat Object: 1 MPI processes
    type: seqaij
    rows=151, cols=151
    total: nonzeros=959, allocated nonzeros=2265
    total number of mallocs used during MatSetValues calls=151
      not using I-node routines
```

Two issues here:
- used matrix type is `seqaij` it should be `mpiaij`
- And only 1 MPI process is used `Mat Object: 1 MPI processes`