### PR TITLE
Use the right accelerator runtime for GPU tests.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,11 +4,8 @@ project(ArcaneFem LANGUAGES C CXX)
 find_package(Arcane REQUIRED)
 arcane_accelerator_enable()
 
-if(ARCANE_HAS_ACCELERATOR)
-  message(STATUS "Arcane has been compiled with cuda. Enabling features that need CUDA.")
-endif()
-
 enable_testing()
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Utils.cmake)
 
 set(MSH_DIR ${CMAKE_SOURCE_DIR}/meshes/msh)
 

--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -1,0 +1,47 @@
+﻿
+unset(ARCANE_ACCELERATOR_RUNTIME)
+if(ARCANE_HAS_ACCELERATOR)
+  if(ARCANE_HAS_CUDA)
+    message(STATUS "Arcane has been compiled with CUDA.")
+    set(ARCANE_ACCELERATOR_RUNTIME "cuda")
+  endif()
+  if(ARCANE_HAS_HIP)
+    message(STATUS "Arcane has been compiled with ROCM/HIP.")
+    set(ARCANE_ACCELERATOR_RUNTIME "hip")
+  endif()
+endif()
+
+# ----------------------------------------------------------------------------
+# Usage:
+#
+# arcanefem_add_gpu_test(NAME test_name [NB_MPI n] COMMAND exe_fileARGS exe_args)
+#
+macro(arcanefem_add_gpu_test)
+  set(options NB_MPI)
+  set(oneValueArgs NAME COMMAND)
+  set(multiValueArgs ARGS)
+  cmake_parse_arguments(ARGS "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+  if (NOT ARGS_NAME)
+    message(FATAL_ERROR "No arg NAME for macro 'arcanefem_add_gpu_test'")
+  endif()
+  if (NOT ARGS_COMMAND)
+    message(FATAL_ERROR "No arg COMMAND for macro 'arcanefem_add_gpu_test'")
+  endif()
+  if(ARCANE_HAS_ACCELERATOR)
+    set(_RUNTIME_ARGS "-A,AcceleratorRuntime=${ARCANE_ACCELERATOR_RUNTIME}")
+    if (ARGS_NB_MPI)
+      if (MPIEXEC_EXECUTABLE)
+        add_test(NAME ${ARGS_NAME} COMMAND ${MPIEXEC_EXECUTABLE} -n ${ARGS_NB_MPI} ${ARGS_COMMAND} ${_RUNTIME_ARGS} ${ARGS_ARGS})
+      endif()
+    else()
+      add_test(NAME ${ARGS_NAME} COMMAND ${ARGS_COMMAND} ${_RUNTIME_ARGS} ${ARGS_ARGS})
+    endif()
+  endif()
+endmacro()
+
+# ----------------------------------------------------------------------------
+# Local Variables:
+# tab-width: 2
+# indent-tabs-mode: nil
+# coding: utf-8-with-signature
+# End:

--- a/poisson/CMakeLists.txt
+++ b/poisson/CMakeLists.txt
@@ -106,13 +106,11 @@ if(FEMUTILS_HAS_SOLVER_BACKEND_PETSC)
 endif()
 
 
-if(ARCANE_HAS_ACCELERATOR)
-  add_test(NAME [poisson]poisson_gpu COMMAND ./Poisson -A,AcceleratorRuntime=cuda Test.poisson.petsc.arc)
-  if(FEMUTILS_HAS_SOLVER_BACKEND_HYPRE)
-    add_test(NAME [poisson]poisson_hypre_direct_gpu COMMAND ./Poisson -A,AcceleratorRuntime=cuda Test.poisson.hypre_direct.arc)
-    if(FEMUTILS_HAS_PARALLEL_SOLVER AND MPIEXEC_EXECUTABLE)
-      add_test(NAME [poisson]poisson_hypre_direct_gpu_4pe COMMAND ${MPIEXEC_EXECUTABLE} -n 4 ./Poisson -A,AcceleratorRuntime=cuda Test.poisson.hypre_direct.arc)
-    endif()
+arcanefem_add_gpu_test(NAME [poisson]poisson_gpu COMMAND ./Poisson ARGS Test.poisson.petsc.arc)
+if(FEMUTILS_HAS_SOLVER_BACKEND_HYPRE)
+  arcanefem_add_gpu_test(NAME [poisson]poisson_hypre_direct_gpu COMMAND ./Poisson ARGS Test.poisson.hypre_direct.arc)
+  if(FEMUTILS_HAS_PARALLEL_SOLVER)
+    arcanefem_add_gpu_test(NAME [poisson]poisson_hypre_direct_gpu_4pe NB_MPI 4 COMMAND ./Poisson ARGS Test.poisson.hypre_direct.arc)
   endif()
 endif()
 


### PR DESCRIPTION
Add a CMake macro `arcanefem_add_gpu_test` to handle that.
It uses `hip` or `cuda` runtime depending of the API used to compile Arcane.

Should fix #122 