### PR TITLE
Fix compilation with Hypre 2.14.

### DIFF
--- a/femutils/HypreDoFLinearSystem.cc
+++ b/femutils/HypreDoFLinearSystem.cc
@@ -102,7 +102,9 @@ class HypreDoFLinearSystemImpl
   ~HypreDoFLinearSystemImpl()
   {
     info() << "Calling HYPRE_Finalize";
+#if HYPRE_RELEASE_NUMBER >= 21500
     HYPRE_Finalize(); /* must be the last HYPRE function call */
+#endif
   }
 
  public:


### PR DESCRIPTION
The function 'HYPRE_Finalize()' is only valid for version 2.15 and after.