### PR TITLE
fix[poisson]: coo & s-coo on the same base

### DIFF
--- a/femutils/CooFormatMatrix.h
+++ b/femutils/CooFormatMatrix.h
@@ -296,4 +296,52 @@ class CooFormat : TraceAccessor
     m_matrix_value(j) = tmp_val;
   }
 };
+
+ARCCORE_HOST_DEVICE Int32 findIndexBinarySearch(Int32 row, Int32 col,
+                                                const auto& in_row_coo,
+                                                const auto& in_col_coo,
+                                                Int32 row_length)
+{
+  Int32 begin = 0;
+  Int32 end = row_length - 1;
+  Int32 i = -1; // Default value in case the index is not found
+
+  // Binary search to find the first occurrence of `row`
+  while (begin <= end) {
+    Int32 mid = begin + (end - begin) / 2;
+
+    if (row == in_row_coo(mid)) {
+      // Move back to the first occurrence of the row
+      while (mid > 0 && in_row_coo(mid - 1) == row) {
+        mid--;
+      }
+      i = mid;
+      break;
+    }
+
+    if (row > in_row_coo(mid)) {
+      begin = mid + 1;
+    }
+    else {
+      end = mid - 1;
+    }
+  }
+
+  // If no occurrence of the row was found, return -1
+  if (i == -1) {
+    return -1;
+  }
+
+  // Search for the matching column in the found row's block
+  while (i < row_length && in_row_coo(i) == row) {
+    if (in_col_coo(i) == col) {
+      return i;
+    }
+    i++;
+  }
+
+  // If no matching column is found, return -1
+  return -1;
+}
+
 } // namespace Arcane::FemUtils

--- a/poisson/CMakeLists.txt
+++ b/poisson/CMakeLists.txt
@@ -1,10 +1,8 @@
 set(ACCELERATOR_SOURCES
   FemModule.cc
-  CooBiliAssembly.cc
-  CsrBiliAssembly.cc
-  CooSortBiliAssembly.cc
   BlCsrBiliAssembly.cc
   CooGpuBiliAssembly.cc
+  CooSortGpuBiliAssembly.cc
   CsrGpuBiliAssembly.cc
   NodeWiseCsrBiliAssembly.cc
 )
@@ -13,6 +11,9 @@ add_executable(Poisson
   ${ACCELERATOR_SOURCES}
   FemModule.h
   LegacyBiliAssembly.cc
+  CooBiliAssembly.cc
+  CsrBiliAssembly.cc
+  CooSortBiliAssembly.cc
   FemModule.cc
   main.cc
   Fem_axl.h

--- a/poisson/FemModule.cc
+++ b/poisson/FemModule.cc
@@ -280,26 +280,26 @@ _doStationarySolve()
   }
 
   if (m_use_coo_gpu) {
-    void (FemModule::*assembly_fun)(bool must_sort) = dim == 2 ? &FemModule::_assembleCooGPUBilinearOperatorTRIA3 : &FemModule::_assembleCooGPUBilinearOperatorTETRA4;
+    void (FemModule::*assembly_fun)() = dim == 2 ? &FemModule::_assembleCooGPUBilinearOperatorTRIA3 : &FemModule::_assembleCooGPUBilinearOperatorTETRA4;
     m_linear_system.clearValues();
-    (this->*assembly_fun)(false);
+    (this->*assembly_fun)();
     if (m_cache_warming != 1)
       m_time_stats->resetStats("AssembleBilinearOperator_Coo_GPU");
     for (auto i = 1; i < m_cache_warming; ++i) {
       m_linear_system.clearValues();
-      (this->*assembly_fun)(false);
+      (this->*assembly_fun)();
     }
   }
 
   if (m_use_coo_sort_gpu) {
-    void (FemModule::*assembly_fun)(bool must_sort) = dim == 2 ? &FemModule::_assembleCooGPUBilinearOperatorTRIA3 : &FemModule::_assembleCooGPUBilinearOperatorTETRA4;
+    void (FemModule::*assembly_fun)() = dim == 2 ? &FemModule::_assembleCooSortGPUBilinearOperatorTRIA3 : &FemModule::_assembleCooSortGPUBilinearOperatorTETRA4;
     m_linear_system.clearValues();
-    (this->*assembly_fun)(true);
+    (this->*assembly_fun)();
     if (m_cache_warming != 1)
       m_time_stats->resetStats("AssembleBilinearOperator_CooSort_GPU");
     for (auto i = 1; i < m_cache_warming; ++i) {
       m_linear_system.clearValues();
-      (this->*assembly_fun)(true);
+      (this->*assembly_fun)();
     }
   }
 

--- a/poisson/FemModule.h
+++ b/poisson/FemModule.h
@@ -266,9 +266,13 @@ class FemModule
  private:
  public:
 
-  void _buildMatrixCooGPU(bool must_sort);
-  void _assembleCooGPUBilinearOperatorTRIA3(bool must_sort);
-  void _assembleCooGPUBilinearOperatorTETRA4(bool must_sort);
+  void _buildMatrixCooGPU();
+  void _assembleCooGPUBilinearOperatorTRIA3();
+  void _assembleCooGPUBilinearOperatorTETRA4();
+
+  void _buildMatrixCooSortGPU();
+  void _assembleCooSortGPUBilinearOperatorTRIA3();
+  void _assembleCooSortGPUBilinearOperatorTETRA4();
 
  private:
 


### PR DESCRIPTION
- S-Coo race condition proof functions have been put in a separate file (`CooSortGpuBiliAssembly.cc`).
- Coo and S-Coo (race cond proof) are now based on the same functions, making Coo takes advantage of the sort implied by Arcane.
- The old Coo (race cond proof) version (with unsorted Row and Column array) is still in the code but commented.