### PR TITLE
Poisson benchmark fixes and improvments

### DIFF
--- a/poisson/CooGpuBiliAssembly.cc
+++ b/poisson/CooGpuBiliAssembly.cc
@@ -324,7 +324,7 @@ _assembleCooGPUBilinearOperatorTRIA3()
   Arcane::ItemGenericInfoListView nodes_infos(this->mesh()->nodeFamily());
   Arcane::ItemGenericInfoListView cells_infos(this->mesh()->cellFamily());
 
-  Timer::Action timer_add_compute(m_time_stats, "ComputeAndAdd");
+  Timer::Action timer_add_compute(m_time_stats, "AddAndCompute");
 
   command << RUNCOMMAND_ENUMERATE(Cell, icell, allCells())
   {
@@ -384,7 +384,7 @@ _assembleCooGPUBilinearOperatorTETRA4()
   Arcane::ItemGenericInfoListView nodes_infos(this->mesh()->nodeFamily());
   Arcane::ItemGenericInfoListView cells_infos(this->mesh()->cellFamily());
 
-  Timer::Action timer_add_compute(m_time_stats, "ComputeAndAdd");
+  Timer::Action timer_add_compute(m_time_stats, "AddAndCompute");
 
   command << RUNCOMMAND_ENUMERATE(Cell, icell, allCells())
   {

--- a/poisson/CooSortGpuBiliAssembly.cc
+++ b/poisson/CooSortGpuBiliAssembly.cc
@@ -243,7 +243,7 @@ _assembleCooSortGPUBilinearOperatorTRIA3()
   Arcane::ItemGenericInfoListView nodes_infos(this->mesh()->nodeFamily());
   Arcane::ItemGenericInfoListView cells_infos(this->mesh()->cellFamily());
 
-  Timer::Action timer_add_compute(m_time_stats, "ComputeAndAdd");
+  Timer::Action timer_add_compute(m_time_stats, "AddAndCompute");
 
   command << RUNCOMMAND_ENUMERATE(Cell, icell, allCells())
   {
@@ -303,7 +303,7 @@ _assembleCooSortGPUBilinearOperatorTETRA4()
   Arcane::ItemGenericInfoListView nodes_infos(this->mesh()->nodeFamily());
   Arcane::ItemGenericInfoListView cells_infos(this->mesh()->cellFamily());
 
-  Timer::Action timer_add_compute(m_time_stats, "ComputeAndAdd");
+  Timer::Action timer_add_compute(m_time_stats, "AddAndCompute");
 
   command << RUNCOMMAND_ENUMERATE(Cell, icell, allCells())
   {

--- a/poisson/LegacyBiliAssembly.cc
+++ b/poisson/LegacyBiliAssembly.cc
@@ -19,6 +19,7 @@ _assembleBilinearOperatorTRIA3()
   auto node_dof(m_dofs_on_nodes.nodeDoFConnectivityView());
 
   Timer::Action timer_action(m_time_stats, "AssembleBilinearOperator_Legacy");
+  Timer::Action timer_add_compute(m_time_stats, "AddAndCompute");
 
   ENUMERATE_ (Cell, icell, allCells()) {
     Cell cell = *icell;
@@ -54,6 +55,7 @@ _assembleBilinearOperatorTETRA4()
   auto node_dof(m_dofs_on_nodes.nodeDoFConnectivityView());
 
   Timer::Action timer_action(m_time_stats, "AssembleBilinearOperator_Legacy");
+  Timer::Action timer_add_compute(m_time_stats, "AddAndCompute");
 
   ENUMERATE_ (Cell, icell, allCells()) {
     Cell cell = *icell;

--- a/poisson/TEST_TEMPLATE_2D.xml
+++ b/poisson/TEST_TEMPLATE_2D.xml
@@ -20,11 +20,17 @@
   </meshes>
 
   <fem>
-    <f>-5.5</f>
+    <f>5.5</f>
     <dirichlet-boundary-condition>
-      <surface>boundary</surface>
+      <surface>horizontal</surface>
       <value>0.5</value>
     </dirichlet-boundary-condition>
+    <linear-system name="HypreLinearSystem">
+      <rtol>0.</rtol>
+      <atol>1e-5</atol>
+      <amg-threshold>0.25</amg-threshold>
+    </linear-system>
+    <blcsr>true</blcsr>
     <!-- FORMATS -->
   </fem>
 </case>

--- a/poisson/doBenchmark.sh
+++ b/poisson/doBenchmark.sh
@@ -26,9 +26,9 @@ SIZES=("small" "medium" "large")
 
 # 2D mesh templates and paths for each size
 TEMPLATE_FILENAME_2D="$(pwd)/TEST_TEMPLATE_2D.xml"
-MESH_2D_SMALL="$(pwd)/L-shape-small.msh"
-MESH_2D_MEDIUM="$(pwd)/L-shape-medium.msh"
-MESH_2D_LARGE="$(pwd)/L-shape-large.msh"
+MESH_2D_SMALL="$(pwd)/circle_cut-small.msh"
+MESH_2D_MEDIUM="$(pwd)/circle_cut-medium.msh"
+MESH_2D_LARGE="$(pwd)/circle_cut-large.msh"
 
 # 3D mesh templates and paths for each size
 TEMPLATE_FILENAME_3D="$(pwd)/TEST_TEMPLATE_3D.xml"
@@ -42,8 +42,10 @@ MESH_3D_LARGE="$(pwd)/L-shape-3D-large.msh"
 #--------------------------------------------------------------------------------------
 
 # Formats to test
-CPU_FORMATS=("legacy" "coo" "coo-sorting" "csr")
-GPU_FORMATS=("coo-gpu" "coo-sorting-gpu" "csr-gpu" "nwcsr" "blcsr")
+# Attention ! When using Hypre linear system, "legacy" format won't work
+# blcsr is the last used format in ArcaneFEM
+CPU_FORMATS=("coo" "csr")
+GPU_FORMATS=("coo-gpu" "csr-gpu" "nwcsr" "blcsr")
 
 # Number of MPI instances to test for each configuration
 CPU_CORE_NUMBERS=(1)

--- a/poisson/get_stats_from_json.py
+++ b/poisson/get_stats_from_json.py
@@ -80,9 +80,16 @@ def main(file_path, metrics=None, config_path=None):
 
             for key in metrics:
                 key_obj = find_key(format_raw_obj, key)
+
                 if key_obj is not None:
                     time = key_obj['Cumulative'].split(' ')[0]
+
+                    if cacheWarming > 1:
+                        time = float(time) / (cacheWarming - 1)
+
                     output.append('{0: <50}'.format(f"  {key}_{format}:") + f"  {time}")
+                else:
+                    output.append('{0: <50}'.format(f"  {key}_{format}:") + f"  undefined")
 
             output.append('') # newline between formats
 

--- a/poisson/get_stats_from_json.py
+++ b/poisson/get_stats_from_json.py
@@ -31,7 +31,8 @@ def load_metrics(config_path):
         sys.exit(1)
 
 def main(file_path, metrics=None, config_path=None):
-    formats = [
+    formats = ["legacy", "coo", "coo-sorting", "coo-gpu", "coo-sorting-gpu", "csr", "csr-gpu", "nwcsr", "blcsr"]
+    formats_maj = [
         "Legacy", "Coo", "CooSort", "Coo_Gpu", "CooSort_Gpu", 
         "Csr", "Csr_Gpu", "CsrNodeWise", "CsrBuildLess"
     ]
@@ -66,8 +67,8 @@ def main(file_path, metrics=None, config_path=None):
     output.append('{0: <30}'.format(f'Boundary element:') + '{0: >5}'.format(str(obj["nbBoundaryElement"])))
     output.append('{0: <30}'.format(f'Element:') + '{0: >5}'.format(str(obj["nbElement"])) + '\n')
 
-    for format in formats:
-        metric_name = f"AssembleBilinearOperator_{format}"
+    for idx, format_maj in enumerate(formats_maj):
+        metric_name = f"AssembleBilinearOperator_{format_maj}"
         format_raw_obj = find_key(obj, metric_name)
 
         if format_raw_obj is not None:
@@ -76,7 +77,7 @@ def main(file_path, metrics=None, config_path=None):
             if cacheWarming > 1:
                 time = float(time) / (cacheWarming - 1)
 
-            output.append('{0: <50}'.format(f"{metric_name}:") + f"{time}")
+            output.append('{0: <50}'.format(f"AssembleBilinearOperator_{formats[idx]}:") + f"{time}")
 
             for key in metrics:
                 key_obj = find_key(format_raw_obj, key)
@@ -87,9 +88,9 @@ def main(file_path, metrics=None, config_path=None):
                     if cacheWarming > 1:
                         time = float(time) / (cacheWarming - 1)
 
-                    output.append('{0: <50}'.format(f"  {key}_{format}:") + f"  {time}")
+                    output.append('{0: <50}'.format(f"  {key}_{formats[idx]}:") + f"  {time}")
                 else:
-                    output.append('{0: <50}'.format(f"  {key}_{format}:") + f"  undefined")
+                    output.append('{0: <50}'.format(f"  {key}_{formats[idx]}:") + f"  undefined")
 
             output.append('') # newline between formats
 


### PR DESCRIPTION
In this PR, the following fixes / improvments have been done:

- Fix "AddAndCompute" timers of `COO-GPU` and `S-COO-GPU`.
- Correctly handle sub actions when there is some cache warming.
- `tsv` result file will now be named `results.tsv`.
- For not tested formats, `NaN` will appear in `results.tsv`  (as `gnuplot` will ignore it).
- 2D template test is now based on `circle_cut.msh`, it uses `Hypre` linear system feature of ArcaneFEM. It worth saying that the `legacy` format cannot be used for this template as the `Hypre` linear system does not support it, and that the assembly functions of the legacy format directly write into the linear system. A possible solution would be to edit the code, but in this case the legacy format won't be comparable to other formats as before, as the assembly function would be modified.