### PR TITLE
Fixed the overflow with the new uid of DoF related to the arcane subdivider service

### DIFF
--- a/femutils/FemDoFsOnNodes.cc
+++ b/femutils/FemDoFsOnNodes.cc
@@ -12,7 +12,7 @@
 /*---------------------------------------------------------------------------*/
 
 #include "FemDoFsOnNodes.h"
-
+#include <arcane/core/MeshUtils.h>
 #include <arcane/mesh/DoFFamily.h>
 #include "arcane/IIndexedIncrementalItemConnectivityMng.h"
 #include "arcane/IIndexedIncrementalItemConnectivity.h"
@@ -79,11 +79,14 @@ initialize(IMesh* mesh, Int32 nb_dof_per_node)
   Int64UniqueArray uids(mesh->allNodes().size() * nb_dof_per_node);
   {
     Integer dof_index = 0;
+    UniqueArray<Int64> hash_maker({0,0});
     ENUMERATE_NODE (inode, mesh->allNodes()) {
       Node node = *inode;
       Int64 node_unique_id = node.uniqueId().asInt64();
+      hash_maker[0] = node_unique_id;
       for (Integer i = 0; i < nb_dof_per_node; ++i) {
-        uids[dof_index] = node_unique_id * nb_dof_per_node + i;
+        hash_maker[1] = i;
+        uids[dof_index] = MeshUtils::generateHashUniqueId(hash_maker.constView());
         ++dof_index;
       }
     }

--- a/modules/elasticity/CMakeLists.txt
+++ b/modules/elasticity/CMakeLists.txt
@@ -81,6 +81,11 @@ if(FEMUTILS_HAS_SOLVER_BACKEND_PETSC)
     -A,//fem/matrix-format=DOK
     inputs/bar.2D.PointDirichlet.arc)
 
+  add_test(NAME [elasticity]3D_Dirichlet_bodyforce_subdivider COMMAND Elasticity ARGS
+  -A,//fem/cross-validation=false 
+  -A,//meshes/mesh/subdivider/nb-subdivision=2
+  inputs/bar.3D.Dirichlet.bodyForce.arc)
+
   arcanefem_add_gpu_test(NAME [elasticity]Dirichlet_pointBC_bsr COMMAND  ./Elasticity ARGS
     -A,//fem/matrix-format=BSR
     inputs/bar.3D.Dirichlet.bodyForce.arc)


### PR DESCRIPTION
Added a test for the subdivider on a 3D mesh tettotet. Modified the way to genererate the uid a of DoF. Now they are generate using a hash of a node and the index of the DoF.