### PR TITLE
[femutils] Fix a strange SEGV occuring in some configuration.

### DIFF
--- a/femutils/AlephDoFLinearSystem.cc
+++ b/femutils/AlephDoFLinearSystem.cc
@@ -530,8 +530,10 @@ solve()
                         &residual_norm,
                         m_aleph_params,
                         false);
+
   info() << "[AlephFem] END SOLVING WITH ALEPH r=" << residual_norm
          << " nb_iter=" << nb_iteration;
+
   auto* rhs_vector = m_aleph_kernel->createSolverVector();
   auto* solution_vector = m_aleph_kernel->createSolverVector();
 
@@ -541,8 +543,9 @@ solve()
 
   const bool do_verbose = (nb_dof < 200) && false;
   Int32 index = 0;
+
   VariableDoFReal& solution_variable(this->solutionVariable());
-  ENUMERATE_ (DoF, idof, dof_family->allItems().own()) {
+  ENUMERATE_ (DoF, idof, dofFamily()->allItems().own()) {
     DoF dof = *idof;
 
     solution_variable[dof] = aleph_result[m_aleph_kernel->indexing()->get(solution_variable, dof)];


### PR DESCRIPTION
With some compiler configuration (Debug or Release), it seems `dof_family` in the `ENUMERATE_` is null and so there is a SEGV when using it. If we do some modification in the code (like printing the value of `dof_family'`, the bug disappears.
It may to be a compiler bug (it crashes with GCC 13 or 14 but works with several versions of clang).