### PR TITLE
Optimization for PETSc preallocation

### DIFF
--- a/femutils/DoFLinearSystem.cc
+++ b/femutils/DoFLinearSystem.cc
@@ -218,6 +218,26 @@ public:
     ARCANE_THROW(NotImplementedException, "");
   }
 
+  void setMatrixValues(bool val) override
+  {
+    ARCANE_THROW(NotImplementedException, "");
+  }
+
+  void setMatrixSparsity(bool val) override
+  {
+    ARCANE_THROW(NotImplementedException, "");
+  }
+
+  bool isMatrixSparsityConstant() const override
+  {
+    ARCANE_THROW(NotImplementedException, "");
+  }
+
+  bool isMatrixValuesConstant() const override
+  {
+    ARCANE_THROW(NotImplementedException, "");
+  }
+
   bool hasSetCSRValues() const override { return false; }
   void setRunner(const Runner& r) override { m_runner = r; }
   Runner runner() const { return m_runner; }
@@ -597,6 +617,46 @@ bool DoFLinearSystem::
 isInitialized() const
 {
   return m_p;
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void DoFLinearSystem::
+setMatrixSparsity(const bool val)
+{
+  _checkInit();
+  m_p->setMatrixSparsity(val);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+void DoFLinearSystem::
+setMatrixValues(const bool val)
+{
+  _checkInit();
+  m_p->setMatrixValues(val);
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+bool DoFLinearSystem::
+isMatrixSparsityConstant()
+{
+  _checkInit();
+  return m_p->isMatrixSparsityConstant();
+}
+
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+
+bool DoFLinearSystem::
+isMatrixValuesConstant()
+{
+  _checkInit();
+  return m_p->isMatrixValuesConstant();
 }
 
 /*---------------------------------------------------------------------------*/

--- a/femutils/DoFLinearSystem.cc
+++ b/femutils/DoFLinearSystem.cc
@@ -220,22 +220,22 @@ public:
 
   void setConstantMatrixValues(bool val) override
   {
-    ARCANE_THROW(NotImplementedException, "");
+    // noop
   }
 
   void setConstantMatrixSparsity(bool val) override
   {
-    ARCANE_THROW(NotImplementedException, "");
+    // noop
   }
 
   bool isMatrixSparsityConstant() const override
   {
-    ARCANE_THROW(NotImplementedException, "");
+    return false;
   }
 
   bool isMatrixValuesConstant() const override
   {
-    ARCANE_THROW(NotImplementedException, "");
+    return false;
   }
 
   bool hasSetCSRValues() const override { return false; }

--- a/femutils/DoFLinearSystem.cc
+++ b/femutils/DoFLinearSystem.cc
@@ -218,12 +218,12 @@ public:
     ARCANE_THROW(NotImplementedException, "");
   }
 
-  void setMatrixValues(bool val) override
+  void setConstantMatrixValues(bool val) override
   {
     ARCANE_THROW(NotImplementedException, "");
   }
 
-  void setMatrixSparsity(bool val) override
+  void setConstantMatrixSparsity(bool val) override
   {
     ARCANE_THROW(NotImplementedException, "");
   }
@@ -623,20 +623,20 @@ isInitialized() const
 /*---------------------------------------------------------------------------*/
 
 void DoFLinearSystem::
-setMatrixSparsity(const bool val)
+setConstantMatrixSparsity(const bool val)
 {
   _checkInit();
-  m_p->setMatrixSparsity(val);
+  m_p->setConstantMatrixSparsity(val);
 }
 
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
 void DoFLinearSystem::
-setMatrixValues(const bool val)
+setConstantMatrixValues(const bool val)
 {
   _checkInit();
-  m_p->setMatrixValues(val);
+  m_p->setConstantMatrixValues(val);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/femutils/DoFLinearSystem.h
+++ b/femutils/DoFLinearSystem.h
@@ -333,8 +333,8 @@ class DoFLinearSystem
   VariableDoFReal& getForcedValue();
   VariableDoFBool& getForcedInfo();
 
-  void setMatrixSparsity(bool val);
-  void setMatrixValues(bool val);
+  void setConstantMatrixSparsity(bool val);
+  void setConstantMatrixValues(bool val);
   bool isMatrixSparsityConstant();
   bool isMatrixValuesConstant();
 

--- a/femutils/DoFLinearSystem.h
+++ b/femutils/DoFLinearSystem.h
@@ -333,6 +333,11 @@ class DoFLinearSystem
   VariableDoFReal& getForcedValue();
   VariableDoFBool& getForcedInfo();
 
+  void setMatrixSparsity(bool val);
+  void setMatrixValues(bool val);
+  bool isMatrixSparsityConstant();
+  bool isMatrixValuesConstant();
+
   IDoFLinearSystemFactory* linearSystemFactory() const
   {
     return m_linear_system_factory;

--- a/femutils/DoFLinearSystem.h
+++ b/femutils/DoFLinearSystem.h
@@ -333,9 +333,52 @@ class DoFLinearSystem
   VariableDoFReal& getForcedValue();
   VariableDoFBool& getForcedInfo();
 
+  /*!
+   * \brief Setter de l'attribut m_constant_matrix_sparsity
+   *
+   * Indique si la matrice du système linéaire change de
+   * sparsité (disposition des nnz) entre les appels à la
+   * fonction solve(). Cela permet des optimisations en
+   * termes d'allocations de mémoire, par exemple en
+   * allouant la matrice une seule fois avant les solving
+   * plutôt qu'à chaque appel de solve(). L'attribut est
+   * par défaut initialisé à false.
+   */
   void setConstantMatrixSparsity(bool val);
+
+  /*!
+   * \brief Setter de l'attribut m_constant_matrix_values
+   *
+   * Indique si la matrice du système linéaire change de
+   * valeurs entre les appels à la fonction solve(). Cela
+   * permet certaines optimisations en termes  de copie
+   * de valeurs. L'attribut est par défaut
+   * initialisé à false.
+   */
   void setConstantMatrixValues(bool val);
+
+  /*!
+   * \brief Getter de l'attribut m_constant_matrix_sparsity
+   *
+   * Indique si la matrice du système linéaire change de
+   * sparsité (disposition des nnz) entre les appels à la
+   * fonction solve(). Cela permet des optimisations en
+   * termes d'allocations de mémoire, par exemple en
+   * allouant la matrice une seule fois avant les solving
+   * plutôt qu'à chaque appel de solve(). L'attribut est
+   * par défaut initialisé à false.
+   */
   bool isMatrixSparsityConstant();
+
+  /*!
+   * \brief Getter de l'attribut m_constant_matrix_values
+   *
+   * Indique si la matrice du système linéaire change de
+   * valeurs entre les appels à la fonction solve(). Cela
+   * permet certaines optimisations en termes  de copie
+   * de valeurs. L'attribut est par défaut
+   * initialisé à false.
+   */
   bool isMatrixValuesConstant();
 
   IDoFLinearSystemFactory* linearSystemFactory() const

--- a/femutils/PETScDoFLinearSystem.cc
+++ b/femutils/PETScDoFLinearSystem.cc
@@ -65,9 +65,14 @@ class PETScDoFLinearSystemImpl
     IItemFamily* dof_family = dofFamily();
     IParallelMng* pm = dof_family->parallelMng();
     MPI_Comm mpi_comm = static_cast<MPI_Comm>(pm->communicator());
-    PetscCallAbort(mpi_comm, ISLocalToGlobalMappingDestroy(&m_petsc_map));
-    PetscCallAbort(mpi_comm, MatDestroy(&m_petsc_matrix));
-    PetscCallAbort(mpi_comm, KSPDestroy(&m_petsc_solver_context));
+
+    if (m_constant_matrix_sparsity)
+    {
+      PetscCallAbort(mpi_comm, ISLocalToGlobalMappingDestroy(&m_petsc_map));
+      PetscCallAbort(mpi_comm, MatDestroy(&m_petsc_matrix));
+      PetscCallAbort(mpi_comm, KSPDestroy(&m_petsc_solver_context));
+    }
+
     PetscFinalize();
   }
 
@@ -107,7 +112,10 @@ class PETScDoFLinearSystemImpl
   Vec m_petsc_rhs_vector;
   Mat m_petsc_matrix;
   ISLocalToGlobalMapping m_petsc_map;
+
   bool m_is_initialized = false;
+  bool m_constant_matrix_sparsity = true;
+  bool m_constant_matrix_values = true;
 
  private:
 
@@ -304,7 +312,6 @@ void PETScDoFLinearSystemImpl::_preallocateMatrix()
   coo_cols.copy(csr_view.columns()); // copy column array
 
   PetscCallAbort(mpi_comm, MatSetPreallocationCOOLocal(m_petsc_matrix, csr_view.nbValue(), coo_rows.data(), coo_cols.data()));
-
   PetscCallAbort(mpi_comm, MatAssemblyBegin(m_petsc_matrix, MAT_FINAL_ASSEMBLY));
   PetscCallAbort(mpi_comm, MatAssemblyEnd(m_petsc_matrix, MAT_FINAL_ASSEMBLY));
 
@@ -319,9 +326,21 @@ void PETScDoFLinearSystemImpl::_initSolve()
   IParallelMng* pm = dof_family->parallelMng();
   Runner runner = this->runner();
   MPI_Comm mpi_comm = static_cast<MPI_Comm>(pm->communicator());
+  CSRFormatView csr_view = this->getCSRValues();
+
   _handleParameters(pm);
   _computeMatrixNumeration(mpi_comm);
-  _preallocateMatrix();
+
+  if (m_constant_matrix_sparsity)
+    _preallocateMatrix();
+
+  if (m_constant_matrix_values)
+  {
+    PetscCallAbort(mpi_comm, MatSetValuesCOO(m_petsc_matrix, csr_view.values().data(), INSERT_VALUES));
+    PetscCallAbort(mpi_comm, MatAssemblyBegin(m_petsc_matrix, MAT_FINAL_ASSEMBLY));
+    PetscCallAbort(mpi_comm, MatAssemblyEnd(m_petsc_matrix, MAT_FINAL_ASSEMBLY));
+  }
+
   m_is_initialized = true;
 }
 
@@ -358,43 +377,17 @@ solve()
 
   // TODO: use COO with MatSetPreallocationCOO for better performance
   // TODO: see if we pass pointers to device memory directly when is_use_device==true
+  if (!m_constant_matrix_sparsity)
+    _preallocateMatrix();
+
+  if (!m_constant_matrix_values)
   {
-    // DoFGroup all_dofs = dof_family->allItems();
-
-    // NumArray<PetscInt, MDDim1> indices{ all_dofs.size() };
-    // // info() << "nb total row " << m_nb_total_row;
-
-    // ENUMERATE_DOF (idof, all_dofs) {
-    //   indices[idof.index()] = m_dof_matrix_numbering[idof];
-    //   // info() << "local index: " << idof.index() << " global index: " << indices[idof.index()];
-    // }
-
-    // PetscCallAbort(mpi_comm, ISLocalToGlobalMappingCreate(mpi_comm, 1, all_dofs.size(), indices._internalData(), PETSC_COPY_VALUES, &m_petsc_map));
-
-    // // info() << "Total " << m_nb_total_row << " local: " << m_nb_own_row;
-    // pm->barrier();
-
-    // PetscCallAbort(mpi_comm, MatCreate(mpi_comm, &m_petsc_matrix));
-    // PetscCallAbort(mpi_comm, MatSetSizes(m_petsc_matrix, local_rows, local_rows, global_rows, global_rows));
-    // PetscCallAbort(mpi_comm, MatSetFromOptions(m_petsc_matrix));
-    // PetscCallAbort(mpi_comm, MatSetLocalToGlobalMapping(m_petsc_matrix, m_petsc_map, m_petsc_map));
-
-    // // info() << "nb cols: " << csr_view.nbColumn() << ", nb rows: " << csr_view.nbRow() << ", nb vals: " << csr_view.nbValue();
-
-    // UniqueArray<PetscInt> coo_rows = _CSRToCOO(csr_view.rows(), csr_view.nbValue());
-    // UniqueArray<PetscInt> coo_cols;
-    // // coo_cols.assign(csr_view.columns().begin(), csr_view.columns().end());
-    // coo_cols.copy(csr_view.columns()); // copy column array
-
-    // PetscCallAbort(mpi_comm, MatSetPreallocationCOOLocal(m_petsc_matrix, csr_view.nbValue(), coo_rows.data(), coo_cols.data()));
-    // _preallocateMatrix();
     PetscCallAbort(mpi_comm, MatSetValuesCOO(m_petsc_matrix, csr_view.values().data(), INSERT_VALUES));
+    PetscCallAbort(mpi_comm, MatAssemblyBegin(m_petsc_matrix, MAT_FINAL_ASSEMBLY));
+    PetscCallAbort(mpi_comm, MatAssemblyEnd(m_petsc_matrix, MAT_FINAL_ASSEMBLY));
   }
 
   pm->barrier();
-
-  PetscCallAbort(mpi_comm, MatAssemblyBegin(m_petsc_matrix, MAT_FINAL_ASSEMBLY));
-  PetscCallAbort(mpi_comm, MatAssemblyEnd(m_petsc_matrix, MAT_FINAL_ASSEMBLY));
 
   Real b2 = platform::getRealTime();
 
@@ -488,6 +481,13 @@ solve()
 
   info() << "[PETSc-Info] Wrote solution in solution_variable";
   info() << "[PETSc-Info] Device memory allocation (Mo): " << (a.totalMemory() - a.freeMemory()) / 1e6;
+
+  if (!m_constant_matrix_sparsity)
+  {
+    PetscCallAbort(mpi_comm, ISLocalToGlobalMappingDestroy(&m_petsc_map));
+    PetscCallAbort(mpi_comm, MatDestroy(&m_petsc_matrix));
+    PetscCallAbort(mpi_comm, KSPDestroy(&m_petsc_solver_context));
+  }
 
   PetscCallAbort(mpi_comm, VecDestroy(&m_petsc_solution_vector));
   PetscCallAbort(mpi_comm, VecDestroy(&m_petsc_rhs_vector));

--- a/femutils/PETScDoFLinearSystem.cc
+++ b/femutils/PETScDoFLinearSystem.cc
@@ -328,6 +328,9 @@ void PETScDoFLinearSystemImpl::_initSolve()
   MPI_Comm mpi_comm = static_cast<MPI_Comm>(pm->communicator());
   CSRFormatView csr_view = this->getCSRValues();
 
+  if (m_constant_matrix_values && !m_constant_matrix_sparsity)
+    PetscCallAbort(mpi_comm, PetscError(mpi_comm, __LINE__, "_initSolve", __FILE__, PETSC_ERR_SUP, PETSC_ERROR_INITIAL, "Cannot have constant matrix values and variable matrix sparsity."));
+
   _handleParameters(pm);
   _computeMatrixNumeration(mpi_comm);
 

--- a/femutils/PETScDoFLinearSystem.cc
+++ b/femutils/PETScDoFLinearSystem.cc
@@ -327,7 +327,8 @@ void PETScDoFLinearSystemImpl::_initSolve()
   CSRFormatView csr_view = this->getCSRValues();
 
   if (isMatrixValuesConstant() && !isMatrixSparsityConstant())
-    PetscCallAbort(mpi_comm, PetscError(mpi_comm, __LINE__, "_initSolve", __FILE__, PETSC_ERR_SUP, PETSC_ERROR_INITIAL, "Cannot have constant matrix values and variable matrix sparsity."));
+    // PetscCallAbort(mpi_comm, PetscError(mpi_comm, __LINE__, "_initSolve", __FILE__, PETSC_ERR_SUP, PETSC_ERROR_INITIAL, "Cannot have constant matrix values and variable matrix sparsity."));
+    ARCANE_THROW(NotSupportedException, "Cannot have constant matrix values and variable matrix sparsity.");
 
   _handleParameters(pm);
   _computeMatrixNumeration(mpi_comm);

--- a/femutils/PETScDoFLinearSystem.cc
+++ b/femutils/PETScDoFLinearSystem.cc
@@ -70,6 +70,13 @@ class PETScDoFLinearSystemImpl
   void build()
   {
     PetscFunctionBeginUser;
+    IItemFamily* dof_family = dofFamily();
+    IParallelMng* pm = dof_family->parallelMng();
+    Runner runner = this->runner();
+    MPI_Comm mpi_comm = static_cast<MPI_Comm>(pm->communicator());
+
+    _handleParameters(pm);
+    _computeMatrixNumeration(mpi_comm);
   }
 
   void solve() override;
@@ -100,6 +107,7 @@ class PETScDoFLinearSystemImpl
   Vec m_petsc_solution_vector;
   Vec m_petsc_rhs_vector;
   Mat m_petsc_matrix;
+  ISLocalToGlobalMapping m_petsc_map;
 
  private:
 
@@ -128,6 +136,7 @@ class PETScDoFLinearSystemImpl
 
   void _computeMatrixNumeration(MPI_Comm mpi_comm);
   void _handleParameters(IParallelMng* pm);
+  void _preallocateMatrix();
   UniqueArray<PetscInt> _CSRToCOO(const Span<const int32_t> csr_rows, int32_t nb_value);
 };
 
@@ -257,6 +266,46 @@ UniqueArray<PetscInt> PETScDoFLinearSystemImpl::_CSRToCOO(const Span<const int32
   return coo_rows;
 }
 
+void PETScDoFLinearSystemImpl::_preallocateMatrix()
+{
+  IItemFamily* dof_family = dofFamily();
+  IParallelMng* pm = dof_family->parallelMng();
+  Runner runner = this->runner();
+  MPI_Comm mpi_comm = static_cast<MPI_Comm>(pm->communicator());
+  DoFGroup all_dofs = dof_family->allItems();
+  PetscInt local_rows = m_nb_own_row; // rows this rank owns
+  PetscInt global_rows = m_nb_total_row; // total rows across all ranks
+  CSRFormatView csr_view = this->getCSRValues();
+
+  NumArray<PetscInt, MDDim1> indices{ all_dofs.size() };
+  // info() << "nb total row " << m_nb_total_row;
+
+  ENUMERATE_DOF (idof, all_dofs) {
+    indices[idof.index()] = m_dof_matrix_numbering[idof];
+    // info() << "local index: " << idof.index() << " global index: " << indices[idof.index()];
+  }
+
+  PetscCallAbort(mpi_comm, ISLocalToGlobalMappingCreate(mpi_comm, 1, all_dofs.size(), indices._internalData(), PETSC_COPY_VALUES, &m_petsc_map));
+
+  // info() << "Total " << m_nb_total_row << " local: " << m_nb_own_row;
+  pm->barrier();
+
+  PetscCallAbort(mpi_comm, MatCreate(mpi_comm, &m_petsc_matrix));
+  PetscCallAbort(mpi_comm, MatSetSizes(m_petsc_matrix, local_rows, local_rows, global_rows, global_rows));
+  PetscCallAbort(mpi_comm, MatSetFromOptions(m_petsc_matrix));
+  PetscCallAbort(mpi_comm, MatSetLocalToGlobalMapping(m_petsc_matrix, m_petsc_map, m_petsc_map));
+
+  // info() << "nb cols: " << csr_view.nbColumn() << ", nb rows: " << csr_view.nbRow() << ", nb vals: " << csr_view.nbValue();
+
+  UniqueArray<PetscInt> coo_rows = _CSRToCOO(csr_view.rows(), csr_view.nbValue());
+  UniqueArray<PetscInt> coo_cols;
+  // coo_cols.assign(csr_view.columns().begin(), csr_view.columns().end());
+  coo_cols.copy(csr_view.columns()); // copy column array
+
+  PetscCallAbort(mpi_comm, MatSetPreallocationCOOLocal(m_petsc_matrix, csr_view.nbValue(), coo_rows.data(), coo_cols.data()));
+
+}
+
 void PETScDoFLinearSystemImpl::
 solve()
 {
@@ -267,8 +316,8 @@ solve()
   Runner runner = this->runner();
   MPI_Comm mpi_comm = static_cast<MPI_Comm>(pm->communicator());
 
-  _handleParameters(pm);
-  _computeMatrixNumeration(mpi_comm);
+  // _handleParameters(pm);
+  // _computeMatrixNumeration(mpi_comm);
 
   Parallel::Communicator arcane_comm = pm->communicator();
   if (arcane_comm.isValid())
@@ -291,36 +340,35 @@ solve()
   // TODO: use COO with MatSetPreallocationCOO for better performance
   // TODO: see if we pass pointers to device memory directly when is_use_device==true
   {
-    DoFGroup all_dofs = dof_family->allItems();
+    // DoFGroup all_dofs = dof_family->allItems();
 
-    NumArray<PetscInt, MDDim1> indices{ all_dofs.size() };
-    // info() << "nb total row " << m_nb_total_row;
+    // NumArray<PetscInt, MDDim1> indices{ all_dofs.size() };
+    // // info() << "nb total row " << m_nb_total_row;
 
-    ENUMERATE_DOF (idof, all_dofs) {
-      indices[idof.index()] = m_dof_matrix_numbering[idof];
-      // info() << "local index: " << idof.index() << " global index: " << indices[idof.index()];
-    }
+    // ENUMERATE_DOF (idof, all_dofs) {
+    //   indices[idof.index()] = m_dof_matrix_numbering[idof];
+    //   // info() << "local index: " << idof.index() << " global index: " << indices[idof.index()];
+    // }
 
-    ISLocalToGlobalMapping m_petsc_map;
-    PetscCallAbort(mpi_comm, ISLocalToGlobalMappingCreate(mpi_comm, 1, all_dofs.size(), indices._internalData(), PETSC_COPY_VALUES, &m_petsc_map));
+    // PetscCallAbort(mpi_comm, ISLocalToGlobalMappingCreate(mpi_comm, 1, all_dofs.size(), indices._internalData(), PETSC_COPY_VALUES, &m_petsc_map));
 
-    // info() << "Total " << m_nb_total_row << " local: " << m_nb_own_row;
-    pm->barrier();
+    // // info() << "Total " << m_nb_total_row << " local: " << m_nb_own_row;
+    // pm->barrier();
 
-    PetscCallAbort(mpi_comm, MatCreate(mpi_comm, &m_petsc_matrix));
-    PetscCallAbort(mpi_comm, MatSetSizes(m_petsc_matrix, local_rows, local_rows, global_rows, global_rows));
-    PetscCallAbort(mpi_comm, MatSetFromOptions(m_petsc_matrix));
-    PetscCallAbort(mpi_comm, MatSetLocalToGlobalMapping(m_petsc_matrix, m_petsc_map, m_petsc_map));
-    PetscCallAbort(mpi_comm, ISLocalToGlobalMappingDestroy(&m_petsc_map));
+    // PetscCallAbort(mpi_comm, MatCreate(mpi_comm, &m_petsc_matrix));
+    // PetscCallAbort(mpi_comm, MatSetSizes(m_petsc_matrix, local_rows, local_rows, global_rows, global_rows));
+    // PetscCallAbort(mpi_comm, MatSetFromOptions(m_petsc_matrix));
+    // PetscCallAbort(mpi_comm, MatSetLocalToGlobalMapping(m_petsc_matrix, m_petsc_map, m_petsc_map));
 
-    // info() << "nb cols: " << csr_view.nbColumn() << ", nb rows: " << csr_view.nbRow() << ", nb vals: " << csr_view.nbValue();
+    // // info() << "nb cols: " << csr_view.nbColumn() << ", nb rows: " << csr_view.nbRow() << ", nb vals: " << csr_view.nbValue();
 
-    UniqueArray<PetscInt> coo_rows = _CSRToCOO(csr_view.rows(), csr_view.nbValue());
-    UniqueArray<PetscInt> coo_cols;
-    // coo_cols.assign(csr_view.columns().begin(), csr_view.columns().end());
-    coo_cols.copy(csr_view.columns()); // copy column array
+    // UniqueArray<PetscInt> coo_rows = _CSRToCOO(csr_view.rows(), csr_view.nbValue());
+    // UniqueArray<PetscInt> coo_cols;
+    // // coo_cols.assign(csr_view.columns().begin(), csr_view.columns().end());
+    // coo_cols.copy(csr_view.columns()); // copy column array
 
-    PetscCallAbort(mpi_comm, MatSetPreallocationCOOLocal(m_petsc_matrix, csr_view.nbValue(), coo_rows.data(), coo_cols.data()));
+    // PetscCallAbort(mpi_comm, MatSetPreallocationCOOLocal(m_petsc_matrix, csr_view.nbValue(), coo_rows.data(), coo_cols.data()));
+    _preallocateMatrix();
     PetscCallAbort(mpi_comm, MatSetValuesCOO(m_petsc_matrix, csr_view.values().data(), INSERT_VALUES));
   }
 
@@ -427,6 +475,7 @@ solve()
 
   PetscCallAbort(mpi_comm, VecDestroy(&m_petsc_solution_vector));
   PetscCallAbort(mpi_comm, VecDestroy(&m_petsc_rhs_vector));
+  PetscCallAbort(mpi_comm, ISLocalToGlobalMappingDestroy(&m_petsc_map));
   PetscCallAbort(mpi_comm, MatDestroy(&m_petsc_matrix));
   PetscCallAbort(mpi_comm, KSPDestroy(&m_petsc_solver_context));
 }
@@ -447,12 +496,12 @@ class PETScDoFLinearSystemFactoryService
     auto* x = new PETScDoFLinearSystemImpl(dof_family, solver_name);
     x->options = options();
 
-    x->build();
     x->setRelTolerance(options()->rtol());
     x->setAbsTolerance(options()->atol());
     x->setMaxIter(options()->maxIter());
     x->setSolver(options()->solver());
     x->setPreconditioner(options()->pcType());
+    x->build();
     return x;
   }
 };

--- a/femutils/internal/DoFLinearSystemImplBase.h
+++ b/femutils/internal/DoFLinearSystemImplBase.h
@@ -61,6 +61,11 @@ class DoFLinearSystemImplBase
 
   IItemFamily* dofFamily() const { return m_dof_family; }
 
+  void setMatrixSparsity(const bool val) final { m_constant_matrix_sparsity = val; }
+  void setMatrixValues(const bool val) final { m_constant_matrix_values = val; }
+  bool isMatrixSparsityConstant() const final { return m_constant_matrix_sparsity; }
+  bool isMatrixValuesConstant() const final { return m_constant_matrix_values; }
+
  protected:
 
   OrderedRowColumnMap& _rowColumnEliminationMap() { return m_row_column_elimination_map; }
@@ -77,6 +82,9 @@ class DoFLinearSystemImplBase
   VariableDoFReal m_dof_forced_value;
   VariableDoFByte m_dof_elimination_info;
   VariableDoFReal m_dof_elimination_value;
+
+  bool m_constant_matrix_sparsity;
+  bool m_constant_matrix_values;
 
   //! List of (row,column) which contribute to RowColumn elimination
   OrderedRowColumnMap m_row_column_elimination_map;

--- a/femutils/internal/DoFLinearSystemImplBase.h
+++ b/femutils/internal/DoFLinearSystemImplBase.h
@@ -61,8 +61,8 @@ class DoFLinearSystemImplBase
 
   IItemFamily* dofFamily() const { return m_dof_family; }
 
-  void setMatrixSparsity(const bool val) final { m_constant_matrix_sparsity = val; }
-  void setMatrixValues(const bool val) final { m_constant_matrix_values = val; }
+  void setConstantMatrixSparsity(const bool val) final { m_constant_matrix_sparsity = val; }
+  void setConstantMatrixValues(const bool val) final { m_constant_matrix_values = val; }
   bool isMatrixSparsityConstant() const final { return m_constant_matrix_sparsity; }
   bool isMatrixValuesConstant() const final { return m_constant_matrix_values; }
 

--- a/femutils/internal/DoFLinearSystemImplBase.h
+++ b/femutils/internal/DoFLinearSystemImplBase.h
@@ -83,8 +83,8 @@ class DoFLinearSystemImplBase
   VariableDoFByte m_dof_elimination_info;
   VariableDoFReal m_dof_elimination_value;
 
-  bool m_constant_matrix_sparsity;
-  bool m_constant_matrix_values;
+  bool m_constant_matrix_sparsity = false;
+  bool m_constant_matrix_values = false;
 
   //! List of (row,column) which contribute to RowColumn elimination
   OrderedRowColumnMap m_row_column_elimination_map;

--- a/femutils/internal/DoFLinearSystemImplBase.h
+++ b/femutils/internal/DoFLinearSystemImplBase.h
@@ -83,7 +83,10 @@ class DoFLinearSystemImplBase
   VariableDoFByte m_dof_elimination_info;
   VariableDoFReal m_dof_elimination_value;
 
+  //! Indicates if the matrix changes sparsity between solve() calls
   bool m_constant_matrix_sparsity = false;
+
+  //! Indicates if the matrix changes values between solve() calls
   bool m_constant_matrix_values = false;
 
   //! List of (row,column) which contribute to RowColumn elimination

--- a/femutils/internal/IDoFLinearSystemImpl.h
+++ b/femutils/internal/IDoFLinearSystemImpl.h
@@ -61,6 +61,10 @@ class IDoFLinearSystemImpl
   virtual VariableDoFByte& getEliminationInfo() = 0;
   virtual VariableDoFReal& getEliminationValue() = 0;
   [[nodiscard]] virtual bool hasSetCSRValues() const = 0;
+  virtual void setMatrixSparsity(bool val) = 0;
+  virtual void setMatrixValues(bool val) = 0;
+  [[nodiscard]] virtual bool isMatrixSparsityConstant() const = 0;
+  [[nodiscard]] virtual bool isMatrixValuesConstant() const = 0;
   virtual void setRunner(const Runner& r) = 0;
   [[nodiscard]] virtual Runner runner() const = 0;
 };

--- a/femutils/internal/IDoFLinearSystemImpl.h
+++ b/femutils/internal/IDoFLinearSystemImpl.h
@@ -61,8 +61,8 @@ class IDoFLinearSystemImpl
   virtual VariableDoFByte& getEliminationInfo() = 0;
   virtual VariableDoFReal& getEliminationValue() = 0;
   [[nodiscard]] virtual bool hasSetCSRValues() const = 0;
-  virtual void setMatrixSparsity(bool val) = 0;
-  virtual void setMatrixValues(bool val) = 0;
+  virtual void setConstantMatrixSparsity(bool val) = 0;
+  virtual void setConstantMatrixValues(bool val) = 0;
   [[nodiscard]] virtual bool isMatrixSparsityConstant() const = 0;
   [[nodiscard]] virtual bool isMatrixValuesConstant() const = 0;
   virtual void setRunner(const Runner& r) = 0;

--- a/modules/heat/FemModule.cc
+++ b/modules/heat/FemModule.cc
@@ -89,6 +89,9 @@ compute()
     m_linear_system.setSolverCommandLineArguments(args);
   }
 
+  m_linear_system.setConstantMatrixSparsity(true);
+  m_linear_system.setConstantMatrixValues(true);
+
   _doStationarySolve();
   _updateTime();
 

--- a/modules/soildynamics/FemModule.cc
+++ b/modules/soildynamics/FemModule.cc
@@ -52,6 +52,9 @@ compute()
     m_linear_system.setSolverCommandLineArguments(args);
   }
 
+  m_linear_system.setConstantMatrixSparsity(true);
+  m_linear_system.setConstantMatrixValues(true);
+
   _doStationarySolve();
   if (t >= tmax  && m_cross_validation)
     _validateResults();

--- a/modules/testlab/FemModule.cc
+++ b/modules/testlab/FemModule.cc
@@ -1975,6 +1975,9 @@ _computeElementMatrixTETRA4(Cell cell)
 void FemModuleTestlab::
 _solve()
 {
+  m_linear_system.setConstantMatrixSparsity(true);
+  m_linear_system.setConstantMatrixValues(true);
+
   info() << "[ArcaneFem-Info] Started module _solve()";
   Real elapsedTime = platform::getRealTime();
 
@@ -1982,6 +1985,7 @@ _solve()
   ITimeStats* tstat = m_time_stats;
   Timer::Action timer_action(tstat, "Solving");
 
+  Real start = platform::getRealTime();
   {
     TimeStart = platform::getRealTime();
     Timer::Action ta1(tstat, "LinearSystemSolve1");
@@ -2050,6 +2054,10 @@ _solve()
       info() << "u[" << node.uniqueId() << "] = " << m_u[node];
     }
   }
+
+  Real end = platform::getRealTime();
+
+  info() << "TIME TAKEN:  " << end - start;
 }
 
 /*---------------------------------------------------------------------------*/

--- a/modules/testlab/FemModule.cc
+++ b/modules/testlab/FemModule.cc
@@ -1985,7 +1985,6 @@ _solve()
   ITimeStats* tstat = m_time_stats;
   Timer::Action timer_action(tstat, "Solving");
 
-  Real start = platform::getRealTime();
   {
     TimeStart = platform::getRealTime();
     Timer::Action ta1(tstat, "LinearSystemSolve1");
@@ -2054,10 +2053,6 @@ _solve()
       info() << "u[" << node.uniqueId() << "] = " << m_u[node];
     }
   }
-
-  Real end = platform::getRealTime();
-
-  info() << "TIME TAKEN:  " << end - start;
 }
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
Preallocate the matrix shape (nnz) only one time.
At each call to solve, the matrix will be filled with new values but the same shape.
At the destruction of the ```PETScDoFLinearSystemImpl``` object, all PETSc object will be freed. This include the matrix, the KSP solver and the Local2Global map indices.

Vectors are still allocated and freed at each call to solve.