### PR TITLE
corrected some bugs in the readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,10 @@ mpirun -n 4 ./Elasticity ./inputs/Test.Elasticity.arc
 
 ```bash
 # Single NVIDIA GPU
-mpirun -n 1 -A,AcceleratorRuntime=cuda ./Elasticity ./inputs/Test.Elasticity.arc
+mpirun -n 1  ./Elasticity -A,AcceleratorRuntime=cuda ./inputs/Test.Elasticity.arc
 
 # Single AMD GPU
-mpirun -n 1 -A,AcceleratorRuntime=hip ./Elasticity ./inputs/Test.Elasticity.arc
+mpirun -n 1 ./Elasticity -A,AcceleratorRuntime=hip ./inputs/Test.Elasticity.arc
 ```
 
 > **Note**: Replace `1` with the number of available GPUs
@@ -98,7 +98,7 @@ mpirun -n 1 -A,AcceleratorRuntime=hip ./Elasticity ./inputs/Test.Elasticity.arc
 
 ```bash
 # 8 CPU cores + 1 GPU
-mpirun -n 8 -A,AcceleratorRuntime=cuda ./Elasticity ./inputs/Test.Elasticity.arc
+mpirun -n 8 ./Elasticity -A,AcceleratorRuntime=cuda ./inputs/Test.Elasticity.arc
 ```
 
 For advanced runtime options, consult the [Arcane Launcher Documentation](https://arcaneframework.github.io/arcane/userdoc/html/d8/dd6/arcanedoc_execution_launcher.html).

--- a/modules/laplace/Readme.md
+++ b/modules/laplace/Readme.md
@@ -15,11 +15,20 @@ $$\frac{\partial}{\partial x}\left(\frac{\partial u}{\partial x} \right) + \frac
 
 or in a more compact forms
 
-$$\nabla(\nabla u)= 0 \quad \forall (x,y)\in\Omega^h.$$ or
+$$
+\nabla(\nabla u)= 0 \quad \forall (x,y)\in\Omega^h.
+$$ 
+or
 
-$$\nabla^2 u= 0 \quad \forall (x,y)\in\Omega^h.$$ or
+$$
+\nabla^2 u= 0 \quad \forall (x,y)\in\Omega^h.
+$$ 
+or
 
-$$\Delta^2 u= 0 \quad \forall (x,y)\in\Omega^h.$$ or
+$$
+\Delta^2 u= 0 \quad \forall (x,y)\in\Omega^h.
+$$ 
+or
 
 To complete the problem description,  three first type (Dirichlet) boundary conditions are applied to this problem:
 


### PR DESCRIPTION
This pull request updates documentation to improve clarity and formatting in both the main `README.md` and the Laplace module's `Readme.md`. The changes focus on correcting command usage examples and reformatting mathematical expressions for better readability.

**Documentation improvements:**

* Updated GPU and CPU command examples in `README.md` to correct the placement of the `-A,AcceleratorRuntime` option, ensuring it appears after the executable for both NVIDIA and AMD GPUs, as well as for multi-core CPU usage. Otherwise it doesn't run the code. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L89-R92) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L101-R101)

**Mathematical expression formatting:**

* Reformatted the presentation of Laplace equation variants in `modules/laplace/Readme.md` by placing each equation in its own display math block cause it did not work.