### PR TITLE
Introduce self-hosted runners and Ubuntu 26.04 images

### DIFF
--- a/.github/workflows/acoustics.yml
+++ b/.github/workflows/acoustics.yml
@@ -25,11 +25,21 @@ env:
   OMPI_MCA_rmaps_base_oversubscribe: 1
 
 jobs:
+  check-runner:
+    name: 'Check runner'
+    uses: 'arcaneframework/gh_actions/.github/workflows/check_runner.yml@v3'
+    secrets: inherit
+    with:
+      requested_runner_tag: 'gpu'
+      is_requested_runner_a_gpu_runner: true
+
   tests:
     name: 'Build and Test'
-    runs-on: ubuntu-latest
+    needs: check-runner
+    runs-on: ${{ needs.check-runner.outputs.runner_tag }}
     container:
       image: ghcr.io/arcaneframework/arcane_ubuntu-2404:gcc-14_full_check_latest
+      options: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true', '--runtime nvidia --gpus all', '') }}
 
     steps:
       - name: Define environment paths
@@ -40,7 +50,7 @@ jobs:
           echo "CT_RESULT_DIR=${GITHUB_WORKSPACE}/test" >> $GITHUB_ENV
 
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: ${{ env.SOURCE_DIR }}
 
@@ -64,7 +74,7 @@ jobs:
           ctest --test-dir ${{ env.BUILD_DIR }} --output-junit ${{ env.CT_RESULT_DIR }}/results.xml ${{ env.CT_OPTS }} -R '\[${{ env.MODULE }}\]'
 
       - name: Upload test artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: tests-${{ env.MODULE_DIR }}-artifact

--- a/.github/workflows/acoustics.yml
+++ b/.github/workflows/acoustics.yml
@@ -46,7 +46,9 @@ jobs:
     needs: check-runner
     runs-on: ${{ needs.check-runner.outputs.runner_tag }}
     container:
-      image: ghcr.io/arcaneframework/arcane_ubuntu-2604:full_check_latest
+      image: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true',
+        'ghcr.io/arcaneframework/arcane_ubuntu-2604:cuda_full_check_latest',
+        'ghcr.io/arcaneframework/arcane_ubuntu-2604:full_check_latest') }}
       options: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true', '--runtime nvidia --gpus all', '') }}
 
     steps:

--- a/.github/workflows/acoustics.yml
+++ b/.github/workflows/acoustics.yml
@@ -38,7 +38,7 @@ jobs:
     needs: check-runner
     runs-on: ${{ needs.check-runner.outputs.runner_tag }}
     container:
-      image: ghcr.io/arcaneframework/arcane_ubuntu-2404:gcc-14_full_check_latest
+      image: ghcr.io/arcaneframework/arcane_ubuntu-2604:full_check_latest
       options: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true', '--runtime nvidia --gpus all', '') }}
 
     steps:

--- a/.github/workflows/acoustics.yml
+++ b/.github/workflows/acoustics.yml
@@ -83,6 +83,7 @@ jobs:
       - name: Test
         shell: bash
         run: |
+          [ -f /root/scripts/config_env.sh ] && source /root/scripts/config_env.sh
           mkdir -p ${{ env.CT_RESULT_DIR }}
           ctest --test-dir ${{ env.BUILD_DIR }} --output-junit ${{ env.CT_RESULT_DIR }}/results.xml ${{ env.CT_OPTS }} -R '\[${{ env.MODULE }}\]'
 
@@ -90,6 +91,6 @@ jobs:
         uses: actions/upload-artifact@v7
         if: failure()
         with:
-          name: tests-${{ env.MODULE_DIR }}-artifact
+          name: tests-${{ env.MODULE }}-artifact
           path: ${{ env.CT_RESULT_DIR }}
           retention-days: 7

--- a/.github/workflows/acoustics.yml
+++ b/.github/workflows/acoustics.yml
@@ -11,6 +11,10 @@ on:
       - modules/acoustics/**
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   MODULE_DIR: 'modules/acoustics'
 
@@ -23,8 +27,10 @@ env:
   OMPI_ALLOW_RUN_AS_ROOT: 1
   OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
   OMPI_MCA_rmaps_base_oversubscribe: 1
+  PRTE_MCA_rmaps_default_mapping_policy: :oversubscribe
 
 jobs:
+  # Check if the self-hosted runner with tag "gpu" is available.
   check-runner:
     name: 'Check runner'
     uses: 'arcaneframework/gh_actions/.github/workflows/check_runner.yml@v3'
@@ -32,6 +38,8 @@ jobs:
     with:
       requested_runner_tag: 'gpu'
       is_requested_runner_a_gpu_runner: true
+    # Output : needs.check-runner.outputs.runner_tag -> "gpu" or "ubuntu-latest" (runner github)
+    #          needs.check-runner.outputs.is_a_gpu_runner -> "true" if "gpu" is available, "false" with "ubuntu-latest"
 
   tests:
     name: 'Build and Test'
@@ -48,6 +56,11 @@ jobs:
           echo "SOURCE_DIR=${GITHUB_WORKSPACE}/src" >> $GITHUB_ENV
           echo "BUILD_DIR=${GITHUB_WORKSPACE}/build" >> $GITHUB_ENV
           echo "CT_RESULT_DIR=${GITHUB_WORKSPACE}/test" >> $GITHUB_ENV
+
+      - name: Configure environment
+        shell: bash
+        run: |
+          source /root/scripts/default_alternatives.sh
 
       - name: Checkout repo
         uses: actions/checkout@v6

--- a/.github/workflows/aerodynamics.yml
+++ b/.github/workflows/aerodynamics.yml
@@ -25,11 +25,21 @@ env:
   OMPI_MCA_rmaps_base_oversubscribe: 1
 
 jobs:
+  check-runner:
+    name: 'Check runner'
+    uses: 'arcaneframework/gh_actions/.github/workflows/check_runner.yml@v3'
+    secrets: inherit
+    with:
+      requested_runner_tag: 'gpu'
+      is_requested_runner_a_gpu_runner: true
+
   tests:
     name: 'Build and Test'
-    runs-on: ubuntu-latest
+    needs: check-runner
+    runs-on: ${{ needs.check-runner.outputs.runner_tag }}
     container:
       image: ghcr.io/arcaneframework/arcane_ubuntu-2404:gcc-14_full_check_latest
+      options: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true', '--runtime nvidia --gpus all', '') }}
 
     steps:
       - name: Define environment paths
@@ -40,7 +50,7 @@ jobs:
           echo "CT_RESULT_DIR=${GITHUB_WORKSPACE}/test" >> $GITHUB_ENV
 
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: ${{ env.SOURCE_DIR }}
 
@@ -64,7 +74,7 @@ jobs:
           ctest --test-dir ${{ env.BUILD_DIR }} --output-junit ${{ env.CT_RESULT_DIR }}/results.xml ${{ env.CT_OPTS }} -R '\[${{ env.MODULE }}\]'
 
       - name: Upload test artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: tests-${{ env.MODULE_DIR }}-artifact

--- a/.github/workflows/aerodynamics.yml
+++ b/.github/workflows/aerodynamics.yml
@@ -46,7 +46,9 @@ jobs:
     needs: check-runner
     runs-on: ${{ needs.check-runner.outputs.runner_tag }}
     container:
-      image: ghcr.io/arcaneframework/arcane_ubuntu-2604:full_check_latest
+      image: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true',
+        'ghcr.io/arcaneframework/arcane_ubuntu-2604:cuda_full_check_latest',
+        'ghcr.io/arcaneframework/arcane_ubuntu-2604:full_check_latest') }}
       options: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true', '--runtime nvidia --gpus all', '') }}
 
     steps:

--- a/.github/workflows/aerodynamics.yml
+++ b/.github/workflows/aerodynamics.yml
@@ -38,7 +38,7 @@ jobs:
     needs: check-runner
     runs-on: ${{ needs.check-runner.outputs.runner_tag }}
     container:
-      image: ghcr.io/arcaneframework/arcane_ubuntu-2404:gcc-14_full_check_latest
+      image: ghcr.io/arcaneframework/arcane_ubuntu-2604:full_check_latest
       options: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true', '--runtime nvidia --gpus all', '') }}
 
     steps:

--- a/.github/workflows/aerodynamics.yml
+++ b/.github/workflows/aerodynamics.yml
@@ -83,6 +83,7 @@ jobs:
       - name: Test
         shell: bash
         run: |
+          [ -f /root/scripts/config_env.sh ] && source /root/scripts/config_env.sh
           mkdir -p ${{ env.CT_RESULT_DIR }}
           ctest --test-dir ${{ env.BUILD_DIR }} --output-junit ${{ env.CT_RESULT_DIR }}/results.xml ${{ env.CT_OPTS }} -R '\[${{ env.MODULE }}\]'
 
@@ -90,6 +91,6 @@ jobs:
         uses: actions/upload-artifact@v7
         if: failure()
         with:
-          name: tests-${{ env.MODULE_DIR }}-artifact
+          name: tests-${{ env.MODULE }}-artifact
           path: ${{ env.CT_RESULT_DIR }}
           retention-days: 7

--- a/.github/workflows/aerodynamics.yml
+++ b/.github/workflows/aerodynamics.yml
@@ -11,6 +11,10 @@ on:
       - modules/aerodynamics/**
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   MODULE_DIR: 'modules/aerodynamics'
 
@@ -23,8 +27,10 @@ env:
   OMPI_ALLOW_RUN_AS_ROOT: 1
   OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
   OMPI_MCA_rmaps_base_oversubscribe: 1
+  PRTE_MCA_rmaps_default_mapping_policy: :oversubscribe
 
 jobs:
+  # Check if the self-hosted runner with tag "gpu" is available.
   check-runner:
     name: 'Check runner'
     uses: 'arcaneframework/gh_actions/.github/workflows/check_runner.yml@v3'
@@ -32,6 +38,8 @@ jobs:
     with:
       requested_runner_tag: 'gpu'
       is_requested_runner_a_gpu_runner: true
+    # Output : needs.check-runner.outputs.runner_tag -> "gpu" or "ubuntu-latest" (runner github)
+    #          needs.check-runner.outputs.is_a_gpu_runner -> "true" if "gpu" is available, "false" with "ubuntu-latest"
 
   tests:
     name: 'Build and Test'
@@ -48,6 +56,11 @@ jobs:
           echo "SOURCE_DIR=${GITHUB_WORKSPACE}/src" >> $GITHUB_ENV
           echo "BUILD_DIR=${GITHUB_WORKSPACE}/build" >> $GITHUB_ENV
           echo "CT_RESULT_DIR=${GITHUB_WORKSPACE}/test" >> $GITHUB_ENV
+
+      - name: Configure environment
+        shell: bash
+        run: |
+          source /root/scripts/default_alternatives.sh
 
       - name: Checkout repo
         uses: actions/checkout@v6

--- a/.github/workflows/bilaplacian.yml
+++ b/.github/workflows/bilaplacian.yml
@@ -25,11 +25,21 @@ env:
   OMPI_MCA_rmaps_base_oversubscribe: 1
 
 jobs:
+  check-runner:
+    name: 'Check runner'
+    uses: 'arcaneframework/gh_actions/.github/workflows/check_runner.yml@v3'
+    secrets: inherit
+    with:
+      requested_runner_tag: 'gpu'
+      is_requested_runner_a_gpu_runner: true
+
   tests:
     name: 'Build and Test'
-    runs-on: ubuntu-latest
+    needs: check-runner
+    runs-on: ${{ needs.check-runner.outputs.runner_tag }}
     container:
       image: ghcr.io/arcaneframework/arcane_ubuntu-2404:gcc-14_full_check_latest
+      options: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true', '--runtime nvidia --gpus all', '') }}
 
     steps:
       - name: Define environment paths
@@ -40,7 +50,7 @@ jobs:
           echo "CT_RESULT_DIR=${GITHUB_WORKSPACE}/test" >> $GITHUB_ENV
 
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: ${{ env.SOURCE_DIR }}
 
@@ -64,7 +74,7 @@ jobs:
           ctest --test-dir ${{ env.BUILD_DIR }} --output-junit ${{ env.CT_RESULT_DIR }}/results.xml ${{ env.CT_OPTS }} -R '\[${{ env.MODULE }}\]'
 
       - name: Upload test artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: tests-${{ env.MODULE_DIR }}-artifact

--- a/.github/workflows/bilaplacian.yml
+++ b/.github/workflows/bilaplacian.yml
@@ -46,7 +46,9 @@ jobs:
     needs: check-runner
     runs-on: ${{ needs.check-runner.outputs.runner_tag }}
     container:
-      image: ghcr.io/arcaneframework/arcane_ubuntu-2604:full_check_latest
+      image: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true',
+        'ghcr.io/arcaneframework/arcane_ubuntu-2604:cuda_full_check_latest',
+        'ghcr.io/arcaneframework/arcane_ubuntu-2604:full_check_latest') }}
       options: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true', '--runtime nvidia --gpus all', '') }}
 
     steps:

--- a/.github/workflows/bilaplacian.yml
+++ b/.github/workflows/bilaplacian.yml
@@ -38,7 +38,7 @@ jobs:
     needs: check-runner
     runs-on: ${{ needs.check-runner.outputs.runner_tag }}
     container:
-      image: ghcr.io/arcaneframework/arcane_ubuntu-2404:gcc-14_full_check_latest
+      image: ghcr.io/arcaneframework/arcane_ubuntu-2604:full_check_latest
       options: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true', '--runtime nvidia --gpus all', '') }}
 
     steps:

--- a/.github/workflows/bilaplacian.yml
+++ b/.github/workflows/bilaplacian.yml
@@ -83,6 +83,7 @@ jobs:
       - name: Test
         shell: bash
         run: |
+          [ -f /root/scripts/config_env.sh ] && source /root/scripts/config_env.sh
           mkdir -p ${{ env.CT_RESULT_DIR }}
           ctest --test-dir ${{ env.BUILD_DIR }} --output-junit ${{ env.CT_RESULT_DIR }}/results.xml ${{ env.CT_OPTS }} -R '\[${{ env.MODULE }}\]'
 
@@ -90,6 +91,6 @@ jobs:
         uses: actions/upload-artifact@v7
         if: failure()
         with:
-          name: tests-${{ env.MODULE_DIR }}-artifact
+          name: tests-${{ env.MODULE }}-artifact
           path: ${{ env.CT_RESULT_DIR }}
           retention-days: 7

--- a/.github/workflows/bilaplacian.yml
+++ b/.github/workflows/bilaplacian.yml
@@ -11,6 +11,10 @@ on:
       - modules/bilaplacian/**
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   MODULE_DIR: 'modules/bilaplacian'
 
@@ -23,8 +27,10 @@ env:
   OMPI_ALLOW_RUN_AS_ROOT: 1
   OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
   OMPI_MCA_rmaps_base_oversubscribe: 1
+  PRTE_MCA_rmaps_default_mapping_policy: :oversubscribe
 
 jobs:
+  # Check if the self-hosted runner with tag "gpu" is available.
   check-runner:
     name: 'Check runner'
     uses: 'arcaneframework/gh_actions/.github/workflows/check_runner.yml@v3'
@@ -32,6 +38,8 @@ jobs:
     with:
       requested_runner_tag: 'gpu'
       is_requested_runner_a_gpu_runner: true
+    # Output : needs.check-runner.outputs.runner_tag -> "gpu" or "ubuntu-latest" (runner github)
+    #          needs.check-runner.outputs.is_a_gpu_runner -> "true" if "gpu" is available, "false" with "ubuntu-latest"
 
   tests:
     name: 'Build and Test'
@@ -48,6 +56,11 @@ jobs:
           echo "SOURCE_DIR=${GITHUB_WORKSPACE}/src" >> $GITHUB_ENV
           echo "BUILD_DIR=${GITHUB_WORKSPACE}/build" >> $GITHUB_ENV
           echo "CT_RESULT_DIR=${GITHUB_WORKSPACE}/test" >> $GITHUB_ENV
+
+      - name: Configure environment
+        shell: bash
+        run: |
+          source /root/scripts/default_alternatives.sh
 
       - name: Checkout repo
         uses: actions/checkout@v6

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -34,7 +34,7 @@ jobs:
           echo "CT_RESULT_DIR=${GITHUB_WORKSPACE}/test" >> $GITHUB_ENV
 
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: ${{ env.SOURCE_DIR }}
 
@@ -71,7 +71,7 @@ jobs:
           rm -v -f *_axl.h.gcov
 
       - name: Upload coverage files to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v7
         env:
           CODECOV_TOKEN : ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -79,7 +79,7 @@ jobs:
           fail_ci_if_error: true
 
       - name: Upload test artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: test-all-modules-artifact

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -7,6 +7,10 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   # CTest
   CT_OPTS: "--timeout 300 --output-on-failure"
@@ -15,13 +19,27 @@ env:
   OMPI_ALLOW_RUN_AS_ROOT: 1
   OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
   OMPI_MCA_rmaps_base_oversubscribe: 1
+  PRTE_MCA_rmaps_default_mapping_policy: :oversubscribe
 
 jobs:
+  # Check if the self-hosted runner with tag "gpu" is available.
+  check-runner:
+    name: 'Check runner'
+    uses: 'arcaneframework/gh_actions/.github/workflows/check_runner.yml@v3'
+    secrets: inherit
+    with:
+      requested_runner_tag: 'gpu'
+      is_requested_runner_a_gpu_runner: true
+    # Output : needs.check-runner.outputs.runner_tag -> "gpu" or "ubuntu-latest" (runner github)
+    #          needs.check-runner.outputs.is_a_gpu_runner -> "true" if "gpu" is available, "false" with "ubuntu-latest"
+
   tests:
     name: 'Build and Test'
-    runs-on: ubuntu-latest
+    needs: check-runner
+    runs-on: ${{ needs.check-runner.outputs.runner_tag }}
     container:
       image: ghcr.io/arcaneframework/arcane_ubuntu-2604:full_release_latest
+      options: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true', '--runtime nvidia --gpus all', '') }}
 
     steps:
       # On place la source à la racine pour éviter

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -38,7 +38,9 @@ jobs:
     needs: check-runner
     runs-on: ${{ needs.check-runner.outputs.runner_tag }}
     container:
-      image: ghcr.io/arcaneframework/arcane_ubuntu-2604:full_release_latest
+      image: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true',
+        'ghcr.io/arcaneframework/arcane_ubuntu-2604:cuda_full_release_latest',
+        'ghcr.io/arcaneframework/arcane_ubuntu-2604:full_release_latest') }}
       options: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true', '--runtime nvidia --gpus all', '') }}
 
     steps:

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -21,7 +21,7 @@ jobs:
     name: 'Build and Test'
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/arcaneframework/arcane_ubuntu-2404:gcc-14_full_release_latest
+      image: ghcr.io/arcaneframework/arcane_ubuntu-2604:full_release_latest
 
     steps:
       # On place la source à la racine pour éviter

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -77,6 +77,29 @@ jobs:
           mkdir -p ${{ env.CT_RESULT_DIR }}
           ctest --test-dir ${{ env.BUILD_DIR }} --output-junit ${{ env.CT_RESULT_DIR }}/results.xml ${{ env.CT_OPTS }}
 
+      # https://www.ibm.com/docs/en/developer-for-zos/9.1.1?topic=formats-junit-xml-format
+      - name: Edit results.xml for Codecov (need valid JUnit XML)
+        shell: bash
+        run: |
+          RESULT_ORI=${{ env.CT_RESULT_DIR }}/results.xml
+          RESULT_TMP=${{ env.CT_RESULT_DIR }}/results_ori.xml
+          mv $RESULT_ORI $RESULT_TMP
+          sed -e '/<testcase.*>/,/<\/testcase>/d' -e 's:</testsuite>::' -e 's/(empty)/CTest ArcaneFem/' -e 's/hostname=""/hostname="GHA"/' $RESULT_TMP > $RESULT_ORI
+          sed -n '/<testcase.*status="fail">/,/<\/testcase>/p' $RESULT_TMP | sed -e 's:<failure message="".*/>::M' -e 's/<system-out>/<failure message="Logs Arcane:">\n/M' -e 's:</system-out>:</failure>:M' >> $RESULT_ORI
+          sed -n '/<testcase.*status="run">/,/<\/testcase>/p' $RESULT_TMP >> $RESULT_ORI
+          echo '</testsuite>' >> $RESULT_ORI
+          rm $RESULT_TMP
+
+      - name: Upload test results to Codecov
+        uses: codecov/codecov-action@v7
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          verbose: true
+          fail_ci_if_error: true
+          files: ${{ env.CT_RESULT_DIR }}/results.xml
+          report_type: test_results
+
       - name: Apply coverage
         shell: bash
         continue-on-error: true

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -74,6 +74,7 @@ jobs:
       - name: Test
         shell: bash
         run: |
+          [ -f /root/scripts/config_env.sh ] && source /root/scripts/config_env.sh
           mkdir -p ${{ env.CT_RESULT_DIR }}
           ctest --test-dir ${{ env.BUILD_DIR }} --output-junit ${{ env.CT_RESULT_DIR }}/results.xml ${{ env.CT_OPTS }}
 

--- a/.github/workflows/elasticity.yml
+++ b/.github/workflows/elasticity.yml
@@ -11,6 +11,10 @@ on:
       - modules/elasticity/**
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   MODULE_DIR: 'modules/elasticity'
 
@@ -23,8 +27,10 @@ env:
   OMPI_ALLOW_RUN_AS_ROOT: 1
   OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
   OMPI_MCA_rmaps_base_oversubscribe: 1
+  PRTE_MCA_rmaps_default_mapping_policy: :oversubscribe
 
 jobs:
+  # Check if the self-hosted runner with tag "gpu" is available.
   check-runner:
     name: 'Check runner'
     uses: 'arcaneframework/gh_actions/.github/workflows/check_runner.yml@v3'
@@ -32,6 +38,8 @@ jobs:
     with:
       requested_runner_tag: 'gpu'
       is_requested_runner_a_gpu_runner: true
+    # Output : needs.check-runner.outputs.runner_tag -> "gpu" or "ubuntu-latest" (runner github)
+    #          needs.check-runner.outputs.is_a_gpu_runner -> "true" if "gpu" is available, "false" with "ubuntu-latest"
 
   tests:
     name: 'Build and Test'
@@ -48,6 +56,11 @@ jobs:
           echo "SOURCE_DIR=${GITHUB_WORKSPACE}/src" >> $GITHUB_ENV
           echo "BUILD_DIR=${GITHUB_WORKSPACE}/build" >> $GITHUB_ENV
           echo "CT_RESULT_DIR=${GITHUB_WORKSPACE}/test" >> $GITHUB_ENV
+
+      - name: Configure environment
+        shell: bash
+        run: |
+          source /root/scripts/default_alternatives.sh
 
       - name: Checkout repo
         uses: actions/checkout@v6

--- a/.github/workflows/elasticity.yml
+++ b/.github/workflows/elasticity.yml
@@ -25,11 +25,21 @@ env:
   OMPI_MCA_rmaps_base_oversubscribe: 1
 
 jobs:
+  check-runner:
+    name: 'Check runner'
+    uses: 'arcaneframework/gh_actions/.github/workflows/check_runner.yml@v3'
+    secrets: inherit
+    with:
+      requested_runner_tag: 'gpu'
+      is_requested_runner_a_gpu_runner: true
+
   tests:
     name: 'Build and Test'
-    runs-on: ubuntu-latest
+    needs: check-runner
+    runs-on: ${{ needs.check-runner.outputs.runner_tag }}
     container:
       image: ghcr.io/arcaneframework/arcane_ubuntu-2404:gcc-14_full_check_latest
+      options: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true', '--runtime nvidia --gpus all', '') }}
 
     steps:
       - name: Define environment paths
@@ -40,7 +50,7 @@ jobs:
           echo "CT_RESULT_DIR=${GITHUB_WORKSPACE}/test" >> $GITHUB_ENV
 
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: ${{ env.SOURCE_DIR }}
 
@@ -64,7 +74,7 @@ jobs:
           ctest --test-dir ${{ env.BUILD_DIR }} --output-junit ${{ env.CT_RESULT_DIR }}/results.xml ${{ env.CT_OPTS }} -R '\[${{ env.MODULE }}\]'
 
       - name: Upload test artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: tests-${{ env.MODULE_DIR }}-artifact

--- a/.github/workflows/elasticity.yml
+++ b/.github/workflows/elasticity.yml
@@ -46,7 +46,9 @@ jobs:
     needs: check-runner
     runs-on: ${{ needs.check-runner.outputs.runner_tag }}
     container:
-      image: ghcr.io/arcaneframework/arcane_ubuntu-2604:full_check_latest
+      image: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true',
+        'ghcr.io/arcaneframework/arcane_ubuntu-2604:cuda_full_check_latest',
+        'ghcr.io/arcaneframework/arcane_ubuntu-2604:full_check_latest') }}
       options: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true', '--runtime nvidia --gpus all', '') }}
 
     steps:

--- a/.github/workflows/elasticity.yml
+++ b/.github/workflows/elasticity.yml
@@ -38,7 +38,7 @@ jobs:
     needs: check-runner
     runs-on: ${{ needs.check-runner.outputs.runner_tag }}
     container:
-      image: ghcr.io/arcaneframework/arcane_ubuntu-2404:gcc-14_full_check_latest
+      image: ghcr.io/arcaneframework/arcane_ubuntu-2604:full_check_latest
       options: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true', '--runtime nvidia --gpus all', '') }}
 
     steps:

--- a/.github/workflows/elasticity.yml
+++ b/.github/workflows/elasticity.yml
@@ -83,6 +83,7 @@ jobs:
       - name: Test
         shell: bash
         run: |
+          [ -f /root/scripts/config_env.sh ] && source /root/scripts/config_env.sh
           mkdir -p ${{ env.CT_RESULT_DIR }}
           ctest --test-dir ${{ env.BUILD_DIR }} --output-junit ${{ env.CT_RESULT_DIR }}/results.xml ${{ env.CT_OPTS }} -R '\[${{ env.MODULE }}\]'
 
@@ -90,6 +91,6 @@ jobs:
         uses: actions/upload-artifact@v7
         if: failure()
         with:
-          name: tests-${{ env.MODULE_DIR }}-artifact
+          name: tests-${{ env.MODULE }}-artifact
           path: ${{ env.CT_RESULT_DIR }}
           retention-days: 7

--- a/.github/workflows/elastodynamics.yml
+++ b/.github/workflows/elastodynamics.yml
@@ -25,11 +25,21 @@ env:
   OMPI_MCA_rmaps_base_oversubscribe: 1
 
 jobs:
+  check-runner:
+    name: 'Check runner'
+    uses: 'arcaneframework/gh_actions/.github/workflows/check_runner.yml@v3'
+    secrets: inherit
+    with:
+      requested_runner_tag: 'gpu'
+      is_requested_runner_a_gpu_runner: true
+
   tests:
     name: 'Build and Test'
-    runs-on: ubuntu-latest
+    needs: check-runner
+    runs-on: ${{ needs.check-runner.outputs.runner_tag }}
     container:
       image: ghcr.io/arcaneframework/arcane_ubuntu-2404:gcc-14_full_check_latest
+      options: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true', '--runtime nvidia --gpus all', '') }}
 
     steps:
       - name: Define environment paths
@@ -40,7 +50,7 @@ jobs:
           echo "CT_RESULT_DIR=${GITHUB_WORKSPACE}/test" >> $GITHUB_ENV
 
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: ${{ env.SOURCE_DIR }}
 
@@ -64,7 +74,7 @@ jobs:
           ctest --test-dir ${{ env.BUILD_DIR }} --output-junit ${{ env.CT_RESULT_DIR }}/results.xml ${{ env.CT_OPTS }} -R '\[${{ env.MODULE }}\]'
 
       - name: Upload test artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: tests-${{ env.MODULE_DIR }}-artifact

--- a/.github/workflows/elastodynamics.yml
+++ b/.github/workflows/elastodynamics.yml
@@ -46,7 +46,9 @@ jobs:
     needs: check-runner
     runs-on: ${{ needs.check-runner.outputs.runner_tag }}
     container:
-      image: ghcr.io/arcaneframework/arcane_ubuntu-2604:full_check_latest
+      image: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true',
+        'ghcr.io/arcaneframework/arcane_ubuntu-2604:cuda_full_check_latest',
+        'ghcr.io/arcaneframework/arcane_ubuntu-2604:full_check_latest') }}
       options: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true', '--runtime nvidia --gpus all', '') }}
 
     steps:

--- a/.github/workflows/elastodynamics.yml
+++ b/.github/workflows/elastodynamics.yml
@@ -38,7 +38,7 @@ jobs:
     needs: check-runner
     runs-on: ${{ needs.check-runner.outputs.runner_tag }}
     container:
-      image: ghcr.io/arcaneframework/arcane_ubuntu-2404:gcc-14_full_check_latest
+      image: ghcr.io/arcaneframework/arcane_ubuntu-2604:full_check_latest
       options: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true', '--runtime nvidia --gpus all', '') }}
 
     steps:

--- a/.github/workflows/elastodynamics.yml
+++ b/.github/workflows/elastodynamics.yml
@@ -83,6 +83,7 @@ jobs:
       - name: Test
         shell: bash
         run: |
+          [ -f /root/scripts/config_env.sh ] && source /root/scripts/config_env.sh
           mkdir -p ${{ env.CT_RESULT_DIR }}
           ctest --test-dir ${{ env.BUILD_DIR }} --output-junit ${{ env.CT_RESULT_DIR }}/results.xml ${{ env.CT_OPTS }} -R '\[${{ env.MODULE }}\]'
 
@@ -90,6 +91,6 @@ jobs:
         uses: actions/upload-artifact@v7
         if: failure()
         with:
-          name: tests-${{ env.MODULE_DIR }}-artifact
+          name: tests-${{ env.MODULE }}-artifact
           path: ${{ env.CT_RESULT_DIR }}
           retention-days: 7

--- a/.github/workflows/elastodynamics.yml
+++ b/.github/workflows/elastodynamics.yml
@@ -11,6 +11,10 @@ on:
       - modules/elastodynamics/**
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   MODULE_DIR: 'modules/elastodynamics'
 
@@ -23,8 +27,10 @@ env:
   OMPI_ALLOW_RUN_AS_ROOT: 1
   OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
   OMPI_MCA_rmaps_base_oversubscribe: 1
+  PRTE_MCA_rmaps_default_mapping_policy: :oversubscribe
 
 jobs:
+  # Check if the self-hosted runner with tag "gpu" is available.
   check-runner:
     name: 'Check runner'
     uses: 'arcaneframework/gh_actions/.github/workflows/check_runner.yml@v3'
@@ -32,6 +38,8 @@ jobs:
     with:
       requested_runner_tag: 'gpu'
       is_requested_runner_a_gpu_runner: true
+    # Output : needs.check-runner.outputs.runner_tag -> "gpu" or "ubuntu-latest" (runner github)
+    #          needs.check-runner.outputs.is_a_gpu_runner -> "true" if "gpu" is available, "false" with "ubuntu-latest"
 
   tests:
     name: 'Build and Test'
@@ -48,6 +56,11 @@ jobs:
           echo "SOURCE_DIR=${GITHUB_WORKSPACE}/src" >> $GITHUB_ENV
           echo "BUILD_DIR=${GITHUB_WORKSPACE}/build" >> $GITHUB_ENV
           echo "CT_RESULT_DIR=${GITHUB_WORKSPACE}/test" >> $GITHUB_ENV
+
+      - name: Configure environment
+        shell: bash
+        run: |
+          source /root/scripts/default_alternatives.sh
 
       - name: Checkout repo
         uses: actions/checkout@v6

--- a/.github/workflows/electrostatics.yml
+++ b/.github/workflows/electrostatics.yml
@@ -25,11 +25,21 @@ env:
   OMPI_MCA_rmaps_base_oversubscribe: 1
 
 jobs:
+  check-runner:
+    name: 'Check runner'
+    uses: 'arcaneframework/gh_actions/.github/workflows/check_runner.yml@v3'
+    secrets: inherit
+    with:
+      requested_runner_tag: 'gpu'
+      is_requested_runner_a_gpu_runner: true
+
   tests:
     name: 'Build and Test'
-    runs-on: ubuntu-latest
+    needs: check-runner
+    runs-on: ${{ needs.check-runner.outputs.runner_tag }}
     container:
       image: ghcr.io/arcaneframework/arcane_ubuntu-2404:gcc-14_full_check_latest
+      options: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true', '--runtime nvidia --gpus all', '') }}
 
     steps:
       - name: Define environment paths
@@ -40,7 +50,7 @@ jobs:
           echo "CT_RESULT_DIR=${GITHUB_WORKSPACE}/test" >> $GITHUB_ENV
 
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: ${{ env.SOURCE_DIR }}
 
@@ -64,7 +74,7 @@ jobs:
           ctest --test-dir ${{ env.BUILD_DIR }} --output-junit ${{ env.CT_RESULT_DIR }}/results.xml ${{ env.CT_OPTS }} -R '\[${{ env.MODULE }}\]'
 
       - name: Upload test artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: tests-${{ env.MODULE_DIR }}-artifact

--- a/.github/workflows/electrostatics.yml
+++ b/.github/workflows/electrostatics.yml
@@ -46,7 +46,9 @@ jobs:
     needs: check-runner
     runs-on: ${{ needs.check-runner.outputs.runner_tag }}
     container:
-      image: ghcr.io/arcaneframework/arcane_ubuntu-2604:full_check_latest
+      image: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true',
+        'ghcr.io/arcaneframework/arcane_ubuntu-2604:cuda_full_check_latest',
+        'ghcr.io/arcaneframework/arcane_ubuntu-2604:full_check_latest') }}
       options: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true', '--runtime nvidia --gpus all', '') }}
 
     steps:

--- a/.github/workflows/electrostatics.yml
+++ b/.github/workflows/electrostatics.yml
@@ -38,7 +38,7 @@ jobs:
     needs: check-runner
     runs-on: ${{ needs.check-runner.outputs.runner_tag }}
     container:
-      image: ghcr.io/arcaneframework/arcane_ubuntu-2404:gcc-14_full_check_latest
+      image: ghcr.io/arcaneframework/arcane_ubuntu-2604:full_check_latest
       options: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true', '--runtime nvidia --gpus all', '') }}
 
     steps:

--- a/.github/workflows/electrostatics.yml
+++ b/.github/workflows/electrostatics.yml
@@ -83,6 +83,7 @@ jobs:
       - name: Test
         shell: bash
         run: |
+          [ -f /root/scripts/config_env.sh ] && source /root/scripts/config_env.sh
           mkdir -p ${{ env.CT_RESULT_DIR }}
           ctest --test-dir ${{ env.BUILD_DIR }} --output-junit ${{ env.CT_RESULT_DIR }}/results.xml ${{ env.CT_OPTS }} -R '\[${{ env.MODULE }}\]'
 
@@ -90,6 +91,6 @@ jobs:
         uses: actions/upload-artifact@v7
         if: failure()
         with:
-          name: tests-${{ env.MODULE_DIR }}-artifact
+          name: tests-${{ env.MODULE }}-artifact
           path: ${{ env.CT_RESULT_DIR }}
           retention-days: 7

--- a/.github/workflows/electrostatics.yml
+++ b/.github/workflows/electrostatics.yml
@@ -11,6 +11,10 @@ on:
       - modules/electrostatics/**
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   MODULE_DIR: 'modules/electrostatics'
 
@@ -23,8 +27,10 @@ env:
   OMPI_ALLOW_RUN_AS_ROOT: 1
   OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
   OMPI_MCA_rmaps_base_oversubscribe: 1
+  PRTE_MCA_rmaps_default_mapping_policy: :oversubscribe
 
 jobs:
+  # Check if the self-hosted runner with tag "gpu" is available.
   check-runner:
     name: 'Check runner'
     uses: 'arcaneframework/gh_actions/.github/workflows/check_runner.yml@v3'
@@ -32,6 +38,8 @@ jobs:
     with:
       requested_runner_tag: 'gpu'
       is_requested_runner_a_gpu_runner: true
+    # Output : needs.check-runner.outputs.runner_tag -> "gpu" or "ubuntu-latest" (runner github)
+    #          needs.check-runner.outputs.is_a_gpu_runner -> "true" if "gpu" is available, "false" with "ubuntu-latest"
 
   tests:
     name: 'Build and Test'
@@ -48,6 +56,11 @@ jobs:
           echo "SOURCE_DIR=${GITHUB_WORKSPACE}/src" >> $GITHUB_ENV
           echo "BUILD_DIR=${GITHUB_WORKSPACE}/build" >> $GITHUB_ENV
           echo "CT_RESULT_DIR=${GITHUB_WORKSPACE}/test" >> $GITHUB_ENV
+
+      - name: Configure environment
+        shell: bash
+        run: |
+          source /root/scripts/default_alternatives.sh
 
       - name: Checkout repo
         uses: actions/checkout@v6

--- a/.github/workflows/femutils.yml
+++ b/.github/workflows/femutils.yml
@@ -21,11 +21,21 @@ env:
   OMPI_MCA_rmaps_base_oversubscribe: 1
 
 jobs:
+  check-runner:
+    name: 'Check runner'
+    uses: 'arcaneframework/gh_actions/.github/workflows/check_runner.yml@v3'
+    secrets: inherit
+    with:
+      requested_runner_tag: 'gpu'
+      is_requested_runner_a_gpu_runner: true
+
   tests:
     name: 'Build and Test'
-    runs-on: ubuntu-latest
+    needs: check-runner
+    runs-on: ${{ needs.check-runner.outputs.runner_tag }}
     container:
-      image: ghcr.io/arcaneframework/arcane_ubuntu-2404:gcc-14_full_debug_latest
+      image: ghcr.io/arcaneframework/arcane_ubuntu-2404:gcc-14_full_check_latest
+      options: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true', '--runtime nvidia --gpus all', '') }}
 
     steps:
       - name: Define environment paths
@@ -36,7 +46,7 @@ jobs:
           echo "CT_RESULT_DIR=${GITHUB_WORKSPACE}/test" >> $GITHUB_ENV
 
       - name: Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           path: ${{ env.SOURCE_DIR }}
 
@@ -61,7 +71,7 @@ jobs:
           ctest --test-dir ${{ env.BUILD_DIR }} --output-junit ${{ env.CT_RESULT_DIR }}/results.xml ${{ env.CT_OPTS }}
 
       - name: Upload test artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: all-modules-femutils-artifact

--- a/.github/workflows/femutils.yml
+++ b/.github/workflows/femutils.yml
@@ -34,7 +34,7 @@ jobs:
     needs: check-runner
     runs-on: ${{ needs.check-runner.outputs.runner_tag }}
     container:
-      image: ghcr.io/arcaneframework/arcane_ubuntu-2404:gcc-14_full_check_latest
+      image: ghcr.io/arcaneframework/arcane_ubuntu-2604:full_check_latest
       options: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true', '--runtime nvidia --gpus all', '') }}
 
     steps:

--- a/.github/workflows/femutils.yml
+++ b/.github/workflows/femutils.yml
@@ -11,6 +11,10 @@ on:
       - femutils/**
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   # CTest
   CT_OPTS: "--timeout 300 --output-on-failure"
@@ -19,8 +23,10 @@ env:
   OMPI_ALLOW_RUN_AS_ROOT: 1
   OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
   OMPI_MCA_rmaps_base_oversubscribe: 1
+  PRTE_MCA_rmaps_default_mapping_policy: :oversubscribe
 
 jobs:
+  # Check if the self-hosted runner with tag "gpu" is available.
   check-runner:
     name: 'Check runner'
     uses: 'arcaneframework/gh_actions/.github/workflows/check_runner.yml@v3'
@@ -28,6 +34,8 @@ jobs:
     with:
       requested_runner_tag: 'gpu'
       is_requested_runner_a_gpu_runner: true
+    # Output : needs.check-runner.outputs.runner_tag -> "gpu" or "ubuntu-latest" (runner github)
+    #          needs.check-runner.outputs.is_a_gpu_runner -> "true" if "gpu" is available, "false" with "ubuntu-latest"
 
   tests:
     name: 'Build and Test'
@@ -44,6 +52,11 @@ jobs:
           echo "SOURCE_DIR=${GITHUB_WORKSPACE}/src" >> $GITHUB_ENV
           echo "BUILD_DIR=${GITHUB_WORKSPACE}/build" >> $GITHUB_ENV
           echo "CT_RESULT_DIR=${GITHUB_WORKSPACE}/test" >> $GITHUB_ENV
+
+      - name: Configure environment
+        shell: bash
+        run: |
+          source /root/scripts/default_alternatives.sh
 
       - name: Checkout repo
         uses: actions/checkout@v6

--- a/.github/workflows/femutils.yml
+++ b/.github/workflows/femutils.yml
@@ -80,6 +80,7 @@ jobs:
       - name: Test
         shell: bash
         run: |
+          [ -f /root/scripts/config_env.sh ] && source /root/scripts/config_env.sh
           mkdir -p ${{ env.CT_RESULT_DIR }}
           ctest --test-dir ${{ env.BUILD_DIR }} --output-junit ${{ env.CT_RESULT_DIR }}/results.xml ${{ env.CT_OPTS }}
 

--- a/.github/workflows/femutils.yml
+++ b/.github/workflows/femutils.yml
@@ -42,7 +42,9 @@ jobs:
     needs: check-runner
     runs-on: ${{ needs.check-runner.outputs.runner_tag }}
     container:
-      image: ghcr.io/arcaneframework/arcane_ubuntu-2604:full_check_latest
+      image: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true',
+        'ghcr.io/arcaneframework/arcane_ubuntu-2604:cuda_full_check_latest',
+        'ghcr.io/arcaneframework/arcane_ubuntu-2604:full_check_latest') }}
       options: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true', '--runtime nvidia --gpus all', '') }}
 
     steps:

--- a/.github/workflows/fourier.yml
+++ b/.github/workflows/fourier.yml
@@ -25,11 +25,21 @@ env:
   OMPI_MCA_rmaps_base_oversubscribe: 1
 
 jobs:
+  check-runner:
+    name: 'Check runner'
+    uses: 'arcaneframework/gh_actions/.github/workflows/check_runner.yml@v3'
+    secrets: inherit
+    with:
+      requested_runner_tag: 'gpu'
+      is_requested_runner_a_gpu_runner: true
+
   tests:
     name: 'Build and Test'
-    runs-on: ubuntu-latest
+    needs: check-runner
+    runs-on: ${{ needs.check-runner.outputs.runner_tag }}
     container:
       image: ghcr.io/arcaneframework/arcane_ubuntu-2404:gcc-14_full_check_latest
+      options: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true', '--runtime nvidia --gpus all', '') }}
 
     steps:
       - name: Define environment paths
@@ -40,7 +50,7 @@ jobs:
           echo "CT_RESULT_DIR=${GITHUB_WORKSPACE}/test" >> $GITHUB_ENV
 
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: ${{ env.SOURCE_DIR }}
 
@@ -64,7 +74,7 @@ jobs:
           ctest --test-dir ${{ env.BUILD_DIR }} --output-junit ${{ env.CT_RESULT_DIR }}/results.xml ${{ env.CT_OPTS }} -R '\[${{ env.MODULE }}\]'
 
       - name: Upload test artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: tests-${{ env.MODULE_DIR }}-artifact

--- a/.github/workflows/fourier.yml
+++ b/.github/workflows/fourier.yml
@@ -46,7 +46,9 @@ jobs:
     needs: check-runner
     runs-on: ${{ needs.check-runner.outputs.runner_tag }}
     container:
-      image: ghcr.io/arcaneframework/arcane_ubuntu-2604:full_check_latest
+      image: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true',
+        'ghcr.io/arcaneframework/arcane_ubuntu-2604:cuda_full_check_latest',
+        'ghcr.io/arcaneframework/arcane_ubuntu-2604:full_check_latest') }}
       options: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true', '--runtime nvidia --gpus all', '') }}
 
     steps:

--- a/.github/workflows/fourier.yml
+++ b/.github/workflows/fourier.yml
@@ -38,7 +38,7 @@ jobs:
     needs: check-runner
     runs-on: ${{ needs.check-runner.outputs.runner_tag }}
     container:
-      image: ghcr.io/arcaneframework/arcane_ubuntu-2404:gcc-14_full_check_latest
+      image: ghcr.io/arcaneframework/arcane_ubuntu-2604:full_check_latest
       options: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true', '--runtime nvidia --gpus all', '') }}
 
     steps:

--- a/.github/workflows/fourier.yml
+++ b/.github/workflows/fourier.yml
@@ -83,6 +83,7 @@ jobs:
       - name: Test
         shell: bash
         run: |
+          [ -f /root/scripts/config_env.sh ] && source /root/scripts/config_env.sh
           mkdir -p ${{ env.CT_RESULT_DIR }}
           ctest --test-dir ${{ env.BUILD_DIR }} --output-junit ${{ env.CT_RESULT_DIR }}/results.xml ${{ env.CT_OPTS }} -R '\[${{ env.MODULE }}\]'
 
@@ -90,6 +91,6 @@ jobs:
         uses: actions/upload-artifact@v7
         if: failure()
         with:
-          name: tests-${{ env.MODULE_DIR }}-artifact
+          name: tests-${{ env.MODULE }}-artifact
           path: ${{ env.CT_RESULT_DIR }}
           retention-days: 7

--- a/.github/workflows/fourier.yml
+++ b/.github/workflows/fourier.yml
@@ -11,6 +11,10 @@ on:
       - modules/fourier/**
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   MODULE_DIR: 'modules/fourier'
 
@@ -23,8 +27,10 @@ env:
   OMPI_ALLOW_RUN_AS_ROOT: 1
   OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
   OMPI_MCA_rmaps_base_oversubscribe: 1
+  PRTE_MCA_rmaps_default_mapping_policy: :oversubscribe
 
 jobs:
+  # Check if the self-hosted runner with tag "gpu" is available.
   check-runner:
     name: 'Check runner'
     uses: 'arcaneframework/gh_actions/.github/workflows/check_runner.yml@v3'
@@ -32,6 +38,8 @@ jobs:
     with:
       requested_runner_tag: 'gpu'
       is_requested_runner_a_gpu_runner: true
+    # Output : needs.check-runner.outputs.runner_tag -> "gpu" or "ubuntu-latest" (runner github)
+    #          needs.check-runner.outputs.is_a_gpu_runner -> "true" if "gpu" is available, "false" with "ubuntu-latest"
 
   tests:
     name: 'Build and Test'
@@ -48,6 +56,11 @@ jobs:
           echo "SOURCE_DIR=${GITHUB_WORKSPACE}/src" >> $GITHUB_ENV
           echo "BUILD_DIR=${GITHUB_WORKSPACE}/build" >> $GITHUB_ENV
           echo "CT_RESULT_DIR=${GITHUB_WORKSPACE}/test" >> $GITHUB_ENV
+
+      - name: Configure environment
+        shell: bash
+        run: |
+          source /root/scripts/default_alternatives.sh
 
       - name: Checkout repo
         uses: actions/checkout@v6

--- a/.github/workflows/fouriernl.yml
+++ b/.github/workflows/fouriernl.yml
@@ -25,11 +25,21 @@ env:
   OMPI_MCA_rmaps_base_oversubscribe: 1
 
 jobs:
+  check-runner:
+    name: 'Check runner'
+    uses: 'arcaneframework/gh_actions/.github/workflows/check_runner.yml@v3'
+    secrets: inherit
+    with:
+      requested_runner_tag: 'gpu'
+      is_requested_runner_a_gpu_runner: true
+
   tests:
     name: 'Build and Test'
-    runs-on: ubuntu-latest
+    needs: check-runner
+    runs-on: ${{ needs.check-runner.outputs.runner_tag }}
     container:
       image: ghcr.io/arcaneframework/arcane_ubuntu-2404:gcc-14_full_check_latest
+      options: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true', '--runtime nvidia --gpus all', '') }}
 
     steps:
       - name: Define environment paths
@@ -40,7 +50,7 @@ jobs:
           echo "CT_RESULT_DIR=${GITHUB_WORKSPACE}/test" >> $GITHUB_ENV
 
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: ${{ env.SOURCE_DIR }}
 
@@ -64,7 +74,7 @@ jobs:
           ctest --test-dir ${{ env.BUILD_DIR }} --output-junit ${{ env.CT_RESULT_DIR }}/results.xml ${{ env.CT_OPTS }} -R '\[${{ env.MODULE }}\]'
 
       - name: Upload test artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: tests-${{ env.MODULE_DIR }}-artifact

--- a/.github/workflows/fouriernl.yml
+++ b/.github/workflows/fouriernl.yml
@@ -11,6 +11,10 @@ on:
       - modules/fouriernl/**
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   MODULE_DIR: 'modules/fouriernl'
 
@@ -23,8 +27,10 @@ env:
   OMPI_ALLOW_RUN_AS_ROOT: 1
   OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
   OMPI_MCA_rmaps_base_oversubscribe: 1
+  PRTE_MCA_rmaps_default_mapping_policy: :oversubscribe
 
 jobs:
+  # Check if the self-hosted runner with tag "gpu" is available.
   check-runner:
     name: 'Check runner'
     uses: 'arcaneframework/gh_actions/.github/workflows/check_runner.yml@v3'
@@ -32,6 +38,8 @@ jobs:
     with:
       requested_runner_tag: 'gpu'
       is_requested_runner_a_gpu_runner: true
+    # Output : needs.check-runner.outputs.runner_tag -> "gpu" or "ubuntu-latest" (runner github)
+    #          needs.check-runner.outputs.is_a_gpu_runner -> "true" if "gpu" is available, "false" with "ubuntu-latest"
 
   tests:
     name: 'Build and Test'
@@ -48,6 +56,11 @@ jobs:
           echo "SOURCE_DIR=${GITHUB_WORKSPACE}/src" >> $GITHUB_ENV
           echo "BUILD_DIR=${GITHUB_WORKSPACE}/build" >> $GITHUB_ENV
           echo "CT_RESULT_DIR=${GITHUB_WORKSPACE}/test" >> $GITHUB_ENV
+
+      - name: Configure environment
+        shell: bash
+        run: |
+          source /root/scripts/default_alternatives.sh
 
       - name: Checkout repo
         uses: actions/checkout@v6

--- a/.github/workflows/fouriernl.yml
+++ b/.github/workflows/fouriernl.yml
@@ -46,7 +46,9 @@ jobs:
     needs: check-runner
     runs-on: ${{ needs.check-runner.outputs.runner_tag }}
     container:
-      image: ghcr.io/arcaneframework/arcane_ubuntu-2604:full_check_latest
+      image: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true',
+        'ghcr.io/arcaneframework/arcane_ubuntu-2604:cuda_full_check_latest',
+        'ghcr.io/arcaneframework/arcane_ubuntu-2604:full_check_latest') }}
       options: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true', '--runtime nvidia --gpus all', '') }}
 
     steps:

--- a/.github/workflows/fouriernl.yml
+++ b/.github/workflows/fouriernl.yml
@@ -38,7 +38,7 @@ jobs:
     needs: check-runner
     runs-on: ${{ needs.check-runner.outputs.runner_tag }}
     container:
-      image: ghcr.io/arcaneframework/arcane_ubuntu-2404:gcc-14_full_check_latest
+      image: ghcr.io/arcaneframework/arcane_ubuntu-2604:full_check_latest
       options: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true', '--runtime nvidia --gpus all', '') }}
 
     steps:

--- a/.github/workflows/fouriernl.yml
+++ b/.github/workflows/fouriernl.yml
@@ -83,6 +83,7 @@ jobs:
       - name: Test
         shell: bash
         run: |
+          [ -f /root/scripts/config_env.sh ] && source /root/scripts/config_env.sh
           mkdir -p ${{ env.CT_RESULT_DIR }}
           ctest --test-dir ${{ env.BUILD_DIR }} --output-junit ${{ env.CT_RESULT_DIR }}/results.xml ${{ env.CT_OPTS }} -R '\[${{ env.MODULE }}\]'
 
@@ -90,6 +91,6 @@ jobs:
         uses: actions/upload-artifact@v7
         if: failure()
         with:
-          name: tests-${{ env.MODULE_DIR }}-artifact
+          name: tests-${{ env.MODULE }}-artifact
           path: ${{ env.CT_RESULT_DIR }}
           retention-days: 7

--- a/.github/workflows/heat.yml
+++ b/.github/workflows/heat.yml
@@ -25,11 +25,21 @@ env:
   OMPI_MCA_rmaps_base_oversubscribe: 1
 
 jobs:
+  check-runner:
+    name: 'Check runner'
+    uses: 'arcaneframework/gh_actions/.github/workflows/check_runner.yml@v3'
+    secrets: inherit
+    with:
+      requested_runner_tag: 'gpu'
+      is_requested_runner_a_gpu_runner: true
+
   tests:
     name: 'Build and Test'
-    runs-on: ubuntu-latest
+    needs: check-runner
+    runs-on: ${{ needs.check-runner.outputs.runner_tag }}
     container:
       image: ghcr.io/arcaneframework/arcane_ubuntu-2404:gcc-14_full_check_latest
+      options: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true', '--runtime nvidia --gpus all', '') }}
 
     steps:
       - name: Define environment paths
@@ -40,7 +50,7 @@ jobs:
           echo "CT_RESULT_DIR=${GITHUB_WORKSPACE}/test" >> $GITHUB_ENV
 
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: ${{ env.SOURCE_DIR }}
 
@@ -64,7 +74,7 @@ jobs:
           ctest --test-dir ${{ env.BUILD_DIR }} --output-junit ${{ env.CT_RESULT_DIR }}/results.xml ${{ env.CT_OPTS }} -R '\[${{ env.MODULE }}\]'
 
       - name: Upload test artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: tests-${{ env.MODULE_DIR }}-artifact

--- a/.github/workflows/heat.yml
+++ b/.github/workflows/heat.yml
@@ -46,7 +46,9 @@ jobs:
     needs: check-runner
     runs-on: ${{ needs.check-runner.outputs.runner_tag }}
     container:
-      image: ghcr.io/arcaneframework/arcane_ubuntu-2604:full_check_latest
+      image: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true',
+        'ghcr.io/arcaneframework/arcane_ubuntu-2604:cuda_full_check_latest',
+        'ghcr.io/arcaneframework/arcane_ubuntu-2604:full_check_latest') }}
       options: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true', '--runtime nvidia --gpus all', '') }}
 
     steps:

--- a/.github/workflows/heat.yml
+++ b/.github/workflows/heat.yml
@@ -38,7 +38,7 @@ jobs:
     needs: check-runner
     runs-on: ${{ needs.check-runner.outputs.runner_tag }}
     container:
-      image: ghcr.io/arcaneframework/arcane_ubuntu-2404:gcc-14_full_check_latest
+      image: ghcr.io/arcaneframework/arcane_ubuntu-2604:full_check_latest
       options: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true', '--runtime nvidia --gpus all', '') }}
 
     steps:

--- a/.github/workflows/heat.yml
+++ b/.github/workflows/heat.yml
@@ -83,6 +83,7 @@ jobs:
       - name: Test
         shell: bash
         run: |
+          [ -f /root/scripts/config_env.sh ] && source /root/scripts/config_env.sh
           mkdir -p ${{ env.CT_RESULT_DIR }}
           ctest --test-dir ${{ env.BUILD_DIR }} --output-junit ${{ env.CT_RESULT_DIR }}/results.xml ${{ env.CT_OPTS }} -R '\[${{ env.MODULE }}\]'
 
@@ -90,6 +91,6 @@ jobs:
         uses: actions/upload-artifact@v7
         if: failure()
         with:
-          name: tests-${{ env.MODULE_DIR }}-artifact
+          name: tests-${{ env.MODULE }}-artifact
           path: ${{ env.CT_RESULT_DIR }}
           retention-days: 7

--- a/.github/workflows/heat.yml
+++ b/.github/workflows/heat.yml
@@ -11,6 +11,10 @@ on:
       - modules/heat/**
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   MODULE_DIR: 'modules/heat'
 
@@ -23,8 +27,10 @@ env:
   OMPI_ALLOW_RUN_AS_ROOT: 1
   OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
   OMPI_MCA_rmaps_base_oversubscribe: 1
+  PRTE_MCA_rmaps_default_mapping_policy: :oversubscribe
 
 jobs:
+  # Check if the self-hosted runner with tag "gpu" is available.
   check-runner:
     name: 'Check runner'
     uses: 'arcaneframework/gh_actions/.github/workflows/check_runner.yml@v3'
@@ -32,6 +38,8 @@ jobs:
     with:
       requested_runner_tag: 'gpu'
       is_requested_runner_a_gpu_runner: true
+    # Output : needs.check-runner.outputs.runner_tag -> "gpu" or "ubuntu-latest" (runner github)
+    #          needs.check-runner.outputs.is_a_gpu_runner -> "true" if "gpu" is available, "false" with "ubuntu-latest"
 
   tests:
     name: 'Build and Test'
@@ -48,6 +56,11 @@ jobs:
           echo "SOURCE_DIR=${GITHUB_WORKSPACE}/src" >> $GITHUB_ENV
           echo "BUILD_DIR=${GITHUB_WORKSPACE}/build" >> $GITHUB_ENV
           echo "CT_RESULT_DIR=${GITHUB_WORKSPACE}/test" >> $GITHUB_ENV
+
+      - name: Configure environment
+        shell: bash
+        run: |
+          source /root/scripts/default_alternatives.sh
 
       - name: Checkout repo
         uses: actions/checkout@v6

--- a/.github/workflows/laplace.yml
+++ b/.github/workflows/laplace.yml
@@ -25,11 +25,21 @@ env:
   OMPI_MCA_rmaps_base_oversubscribe: 1
 
 jobs:
+  check-runner:
+    name: 'Check runner'
+    uses: 'arcaneframework/gh_actions/.github/workflows/check_runner.yml@v3'
+    secrets: inherit
+    with:
+      requested_runner_tag: 'gpu'
+      is_requested_runner_a_gpu_runner: true
+
   tests:
     name: 'Build and Test'
-    runs-on: ubuntu-latest
+    needs: check-runner
+    runs-on: ${{ needs.check-runner.outputs.runner_tag }}
     container:
       image: ghcr.io/arcaneframework/arcane_ubuntu-2404:gcc-14_full_check_latest
+      options: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true', '--runtime nvidia --gpus all', '') }}
 
     steps:
       - name: Define environment paths
@@ -40,7 +50,7 @@ jobs:
           echo "CT_RESULT_DIR=${GITHUB_WORKSPACE}/test" >> $GITHUB_ENV
 
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: ${{ env.SOURCE_DIR }}
 
@@ -64,7 +74,7 @@ jobs:
           ctest --test-dir ${{ env.BUILD_DIR }} --output-junit ${{ env.CT_RESULT_DIR }}/results.xml ${{ env.CT_OPTS }} -R '\[${{ env.MODULE }}\]'
 
       - name: Upload test artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: tests-${{ env.MODULE_DIR }}-artifact

--- a/.github/workflows/laplace.yml
+++ b/.github/workflows/laplace.yml
@@ -46,7 +46,9 @@ jobs:
     needs: check-runner
     runs-on: ${{ needs.check-runner.outputs.runner_tag }}
     container:
-      image: ghcr.io/arcaneframework/arcane_ubuntu-2604:full_check_latest
+      image: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true',
+        'ghcr.io/arcaneframework/arcane_ubuntu-2604:cuda_full_check_latest',
+        'ghcr.io/arcaneframework/arcane_ubuntu-2604:full_check_latest') }}
       options: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true', '--runtime nvidia --gpus all', '') }}
 
     steps:

--- a/.github/workflows/laplace.yml
+++ b/.github/workflows/laplace.yml
@@ -38,7 +38,7 @@ jobs:
     needs: check-runner
     runs-on: ${{ needs.check-runner.outputs.runner_tag }}
     container:
-      image: ghcr.io/arcaneframework/arcane_ubuntu-2404:gcc-14_full_check_latest
+      image: ghcr.io/arcaneframework/arcane_ubuntu-2604:full_check_latest
       options: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true', '--runtime nvidia --gpus all', '') }}
 
     steps:

--- a/.github/workflows/laplace.yml
+++ b/.github/workflows/laplace.yml
@@ -11,6 +11,10 @@ on:
       - modules/laplace/**
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   MODULE_DIR: 'modules/laplace'
 
@@ -23,8 +27,10 @@ env:
   OMPI_ALLOW_RUN_AS_ROOT: 1
   OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
   OMPI_MCA_rmaps_base_oversubscribe: 1
+  PRTE_MCA_rmaps_default_mapping_policy: :oversubscribe
 
 jobs:
+  # Check if the self-hosted runner with tag "gpu" is available.
   check-runner:
     name: 'Check runner'
     uses: 'arcaneframework/gh_actions/.github/workflows/check_runner.yml@v3'
@@ -32,6 +38,8 @@ jobs:
     with:
       requested_runner_tag: 'gpu'
       is_requested_runner_a_gpu_runner: true
+    # Output : needs.check-runner.outputs.runner_tag -> "gpu" or "ubuntu-latest" (runner github)
+    #          needs.check-runner.outputs.is_a_gpu_runner -> "true" if "gpu" is available, "false" with "ubuntu-latest"
 
   tests:
     name: 'Build and Test'
@@ -48,6 +56,11 @@ jobs:
           echo "SOURCE_DIR=${GITHUB_WORKSPACE}/src" >> $GITHUB_ENV
           echo "BUILD_DIR=${GITHUB_WORKSPACE}/build" >> $GITHUB_ENV
           echo "CT_RESULT_DIR=${GITHUB_WORKSPACE}/test" >> $GITHUB_ENV
+
+      - name: Configure environment
+        shell: bash
+        run: |
+          source /root/scripts/default_alternatives.sh
 
       - name: Checkout repo
         uses: actions/checkout@v6

--- a/.github/workflows/laplace.yml
+++ b/.github/workflows/laplace.yml
@@ -83,6 +83,7 @@ jobs:
       - name: Test
         shell: bash
         run: |
+          [ -f /root/scripts/config_env.sh ] && source /root/scripts/config_env.sh
           mkdir -p ${{ env.CT_RESULT_DIR }}
           ctest --test-dir ${{ env.BUILD_DIR }} --output-junit ${{ env.CT_RESULT_DIR }}/results.xml ${{ env.CT_OPTS }} -R '\[${{ env.MODULE }}\]'
 
@@ -90,6 +91,6 @@ jobs:
         uses: actions/upload-artifact@v7
         if: failure()
         with:
-          name: tests-${{ env.MODULE_DIR }}-artifact
+          name: tests-${{ env.MODULE }}-artifact
           path: ${{ env.CT_RESULT_DIR }}
           retention-days: 7

--- a/.github/workflows/passmo.yml
+++ b/.github/workflows/passmo.yml
@@ -25,11 +25,21 @@ env:
   OMPI_MCA_rmaps_base_oversubscribe: 1
 
 jobs:
+  check-runner:
+    name: 'Check runner'
+    uses: 'arcaneframework/gh_actions/.github/workflows/check_runner.yml@v3'
+    secrets: inherit
+    with:
+      requested_runner_tag: 'gpu'
+      is_requested_runner_a_gpu_runner: true
+
   tests:
     name: 'Build and Test'
-    runs-on: ubuntu-latest
+    needs: check-runner
+    runs-on: ${{ needs.check-runner.outputs.runner_tag }}
     container:
       image: ghcr.io/arcaneframework/arcane_ubuntu-2404:gcc-14_full_check_latest
+      options: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true', '--runtime nvidia --gpus all', '') }}
 
     steps:
       - name: Define environment paths
@@ -40,7 +50,7 @@ jobs:
           echo "CT_RESULT_DIR=${GITHUB_WORKSPACE}/test" >> $GITHUB_ENV
 
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: ${{ env.SOURCE_DIR }}
 
@@ -64,7 +74,7 @@ jobs:
           ctest --test-dir ${{ env.BUILD_DIR }} --output-junit ${{ env.CT_RESULT_DIR }}/results.xml ${{ env.CT_OPTS }} -R '\[${{ env.MODULE }}\]'
 
       - name: Upload test artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: tests-${{ env.MODULE_DIR }}-artifact

--- a/.github/workflows/passmo.yml
+++ b/.github/workflows/passmo.yml
@@ -46,7 +46,9 @@ jobs:
     needs: check-runner
     runs-on: ${{ needs.check-runner.outputs.runner_tag }}
     container:
-      image: ghcr.io/arcaneframework/arcane_ubuntu-2604:full_check_latest
+      image: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true',
+        'ghcr.io/arcaneframework/arcane_ubuntu-2604:cuda_full_check_latest',
+        'ghcr.io/arcaneframework/arcane_ubuntu-2604:full_check_latest') }}
       options: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true', '--runtime nvidia --gpus all', '') }}
 
     steps:

--- a/.github/workflows/passmo.yml
+++ b/.github/workflows/passmo.yml
@@ -38,7 +38,7 @@ jobs:
     needs: check-runner
     runs-on: ${{ needs.check-runner.outputs.runner_tag }}
     container:
-      image: ghcr.io/arcaneframework/arcane_ubuntu-2404:gcc-14_full_check_latest
+      image: ghcr.io/arcaneframework/arcane_ubuntu-2604:full_check_latest
       options: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true', '--runtime nvidia --gpus all', '') }}
 
     steps:

--- a/.github/workflows/passmo.yml
+++ b/.github/workflows/passmo.yml
@@ -83,6 +83,7 @@ jobs:
       - name: Test
         shell: bash
         run: |
+          [ -f /root/scripts/config_env.sh ] && source /root/scripts/config_env.sh
           mkdir -p ${{ env.CT_RESULT_DIR }}
           ctest --test-dir ${{ env.BUILD_DIR }} --output-junit ${{ env.CT_RESULT_DIR }}/results.xml ${{ env.CT_OPTS }} -R '\[${{ env.MODULE }}\]'
 
@@ -90,6 +91,6 @@ jobs:
         uses: actions/upload-artifact@v7
         if: failure()
         with:
-          name: tests-${{ env.MODULE_DIR }}-artifact
+          name: tests-${{ env.MODULE }}-artifact
           path: ${{ env.CT_RESULT_DIR }}
           retention-days: 7

--- a/.github/workflows/passmo.yml
+++ b/.github/workflows/passmo.yml
@@ -11,6 +11,10 @@ on:
       - modules/passmo/**
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   MODULE_DIR: 'modules/passmo'
 
@@ -23,8 +27,10 @@ env:
   OMPI_ALLOW_RUN_AS_ROOT: 1
   OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
   OMPI_MCA_rmaps_base_oversubscribe: 1
+  PRTE_MCA_rmaps_default_mapping_policy: :oversubscribe
 
 jobs:
+  # Check if the self-hosted runner with tag "gpu" is available.
   check-runner:
     name: 'Check runner'
     uses: 'arcaneframework/gh_actions/.github/workflows/check_runner.yml@v3'
@@ -32,6 +38,8 @@ jobs:
     with:
       requested_runner_tag: 'gpu'
       is_requested_runner_a_gpu_runner: true
+    # Output : needs.check-runner.outputs.runner_tag -> "gpu" or "ubuntu-latest" (runner github)
+    #          needs.check-runner.outputs.is_a_gpu_runner -> "true" if "gpu" is available, "false" with "ubuntu-latest"
 
   tests:
     name: 'Build and Test'
@@ -48,6 +56,11 @@ jobs:
           echo "SOURCE_DIR=${GITHUB_WORKSPACE}/src" >> $GITHUB_ENV
           echo "BUILD_DIR=${GITHUB_WORKSPACE}/build" >> $GITHUB_ENV
           echo "CT_RESULT_DIR=${GITHUB_WORKSPACE}/test" >> $GITHUB_ENV
+
+      - name: Configure environment
+        shell: bash
+        run: |
+          source /root/scripts/default_alternatives.sh
 
       - name: Checkout repo
         uses: actions/checkout@v6

--- a/.github/workflows/poisson.yml
+++ b/.github/workflows/poisson.yml
@@ -11,6 +11,10 @@ on:
       - modules/poisson/**
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   MODULE_DIR: 'modules/poisson'
 
@@ -23,8 +27,10 @@ env:
   OMPI_ALLOW_RUN_AS_ROOT: 1
   OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
   OMPI_MCA_rmaps_base_oversubscribe: 1
+  PRTE_MCA_rmaps_default_mapping_policy: :oversubscribe
 
 jobs:
+  # Check if the self-hosted runner with tag "gpu" is available.
   check-runner:
     name: 'Check runner'
     uses: 'arcaneframework/gh_actions/.github/workflows/check_runner.yml@v3'
@@ -32,6 +38,8 @@ jobs:
     with:
       requested_runner_tag: 'gpu'
       is_requested_runner_a_gpu_runner: true
+    # Output : needs.check-runner.outputs.runner_tag -> "gpu" or "ubuntu-latest" (runner github)
+    #          needs.check-runner.outputs.is_a_gpu_runner -> "true" if "gpu" is available, "false" with "ubuntu-latest"
 
   tests:
     name: 'Build and Test'
@@ -48,6 +56,11 @@ jobs:
           echo "SOURCE_DIR=${GITHUB_WORKSPACE}/src" >> $GITHUB_ENV
           echo "BUILD_DIR=${GITHUB_WORKSPACE}/build" >> $GITHUB_ENV
           echo "CT_RESULT_DIR=${GITHUB_WORKSPACE}/test" >> $GITHUB_ENV
+
+      - name: Configure environment
+        shell: bash
+        run: |
+          source /root/scripts/default_alternatives.sh
 
       - name: Checkout repo
         uses: actions/checkout@v6

--- a/.github/workflows/poisson.yml
+++ b/.github/workflows/poisson.yml
@@ -25,11 +25,21 @@ env:
   OMPI_MCA_rmaps_base_oversubscribe: 1
 
 jobs:
+  check-runner:
+    name: 'Check runner'
+    uses: 'arcaneframework/gh_actions/.github/workflows/check_runner.yml@v3'
+    secrets: inherit
+    with:
+      requested_runner_tag: 'gpu'
+      is_requested_runner_a_gpu_runner: true
+
   tests:
     name: 'Build and Test'
-    runs-on: ubuntu-latest
+    needs: check-runner
+    runs-on: ${{ needs.check-runner.outputs.runner_tag }}
     container:
       image: ghcr.io/arcaneframework/arcane_ubuntu-2404:gcc-14_full_check_latest
+      options: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true', '--runtime nvidia --gpus all', '') }}
 
     steps:
       - name: Define environment paths
@@ -40,7 +50,7 @@ jobs:
           echo "CT_RESULT_DIR=${GITHUB_WORKSPACE}/test" >> $GITHUB_ENV
 
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: ${{ env.SOURCE_DIR }}
 
@@ -64,7 +74,7 @@ jobs:
           ctest --test-dir ${{ env.BUILD_DIR }} --output-junit ${{ env.CT_RESULT_DIR }}/results.xml ${{ env.CT_OPTS }} -R '\[${{ env.MODULE }}\]'
 
       - name: Upload test artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: tests-${{ env.MODULE_DIR }}-artifact

--- a/.github/workflows/poisson.yml
+++ b/.github/workflows/poisson.yml
@@ -46,7 +46,9 @@ jobs:
     needs: check-runner
     runs-on: ${{ needs.check-runner.outputs.runner_tag }}
     container:
-      image: ghcr.io/arcaneframework/arcane_ubuntu-2604:full_check_latest
+      image: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true',
+        'ghcr.io/arcaneframework/arcane_ubuntu-2604:cuda_full_check_latest',
+        'ghcr.io/arcaneframework/arcane_ubuntu-2604:full_check_latest') }}
       options: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true', '--runtime nvidia --gpus all', '') }}
 
     steps:

--- a/.github/workflows/poisson.yml
+++ b/.github/workflows/poisson.yml
@@ -38,7 +38,7 @@ jobs:
     needs: check-runner
     runs-on: ${{ needs.check-runner.outputs.runner_tag }}
     container:
-      image: ghcr.io/arcaneframework/arcane_ubuntu-2404:gcc-14_full_check_latest
+      image: ghcr.io/arcaneframework/arcane_ubuntu-2604:full_check_latest
       options: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true', '--runtime nvidia --gpus all', '') }}
 
     steps:

--- a/.github/workflows/poisson.yml
+++ b/.github/workflows/poisson.yml
@@ -83,6 +83,7 @@ jobs:
       - name: Test
         shell: bash
         run: |
+          [ -f /root/scripts/config_env.sh ] && source /root/scripts/config_env.sh
           mkdir -p ${{ env.CT_RESULT_DIR }}
           ctest --test-dir ${{ env.BUILD_DIR }} --output-junit ${{ env.CT_RESULT_DIR }}/results.xml ${{ env.CT_OPTS }} -R '\[${{ env.MODULE }}\]'
 
@@ -90,6 +91,6 @@ jobs:
         uses: actions/upload-artifact@v7
         if: failure()
         with:
-          name: tests-${{ env.MODULE_DIR }}-artifact
+          name: tests-${{ env.MODULE }}-artifact
           path: ${{ env.CT_RESULT_DIR }}
           retention-days: 7

--- a/.github/workflows/poisson_dg.yml
+++ b/.github/workflows/poisson_dg.yml
@@ -25,11 +25,21 @@ env:
   OMPI_MCA_rmaps_base_oversubscribe: 1
 
 jobs:
+  check-runner:
+    name: 'Check runner'
+    uses: 'arcaneframework/gh_actions/.github/workflows/check_runner.yml@v3'
+    secrets: inherit
+    with:
+      requested_runner_tag: 'gpu'
+      is_requested_runner_a_gpu_runner: true
+
   tests:
     name: 'Build and Test'
-    runs-on: ubuntu-latest
+    needs: check-runner
+    runs-on: ${{ needs.check-runner.outputs.runner_tag }}
     container:
       image: ghcr.io/arcaneframework/arcane_ubuntu-2404:gcc-14_full_check_latest
+      options: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true', '--runtime nvidia --gpus all', '') }}
 
     steps:
       - name: Define environment paths
@@ -40,7 +50,7 @@ jobs:
           echo "CT_RESULT_DIR=${GITHUB_WORKSPACE}/test" >> $GITHUB_ENV
 
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: ${{ env.SOURCE_DIR }}
 
@@ -64,7 +74,7 @@ jobs:
           ctest --test-dir ${{ env.BUILD_DIR }} --output-junit ${{ env.CT_RESULT_DIR }}/results.xml ${{ env.CT_OPTS }} -R '\[${{ env.MODULE }}\]'
 
       - name: Upload test artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: tests-${{ env.MODULE_DIR }}-artifact

--- a/.github/workflows/poisson_dg.yml
+++ b/.github/workflows/poisson_dg.yml
@@ -46,7 +46,9 @@ jobs:
     needs: check-runner
     runs-on: ${{ needs.check-runner.outputs.runner_tag }}
     container:
-      image: ghcr.io/arcaneframework/arcane_ubuntu-2604:full_check_latest
+      image: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true',
+        'ghcr.io/arcaneframework/arcane_ubuntu-2604:cuda_full_check_latest',
+        'ghcr.io/arcaneframework/arcane_ubuntu-2604:full_check_latest') }}
       options: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true', '--runtime nvidia --gpus all', '') }}
 
     steps:

--- a/.github/workflows/poisson_dg.yml
+++ b/.github/workflows/poisson_dg.yml
@@ -38,7 +38,7 @@ jobs:
     needs: check-runner
     runs-on: ${{ needs.check-runner.outputs.runner_tag }}
     container:
-      image: ghcr.io/arcaneframework/arcane_ubuntu-2404:gcc-14_full_check_latest
+      image: ghcr.io/arcaneframework/arcane_ubuntu-2604:full_check_latest
       options: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true', '--runtime nvidia --gpus all', '') }}
 
     steps:

--- a/.github/workflows/poisson_dg.yml
+++ b/.github/workflows/poisson_dg.yml
@@ -83,6 +83,7 @@ jobs:
       - name: Test
         shell: bash
         run: |
+          [ -f /root/scripts/config_env.sh ] && source /root/scripts/config_env.sh
           mkdir -p ${{ env.CT_RESULT_DIR }}
           ctest --test-dir ${{ env.BUILD_DIR }} --output-junit ${{ env.CT_RESULT_DIR }}/results.xml ${{ env.CT_OPTS }} -R '\[${{ env.MODULE }}\]'
 
@@ -90,6 +91,6 @@ jobs:
         uses: actions/upload-artifact@v7
         if: failure()
         with:
-          name: tests-${{ env.MODULE_DIR }}-artifact
+          name: tests-${{ env.MODULE }}-artifact
           path: ${{ env.CT_RESULT_DIR }}
           retention-days: 7

--- a/.github/workflows/poisson_dg.yml
+++ b/.github/workflows/poisson_dg.yml
@@ -11,6 +11,10 @@ on:
       - modules/poisson_dg/**
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   MODULE_DIR: 'modules/poisson_dg'
 
@@ -23,8 +27,10 @@ env:
   OMPI_ALLOW_RUN_AS_ROOT: 1
   OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
   OMPI_MCA_rmaps_base_oversubscribe: 1
+  PRTE_MCA_rmaps_default_mapping_policy: :oversubscribe
 
 jobs:
+  # Check if the self-hosted runner with tag "gpu" is available.
   check-runner:
     name: 'Check runner'
     uses: 'arcaneframework/gh_actions/.github/workflows/check_runner.yml@v3'
@@ -32,6 +38,8 @@ jobs:
     with:
       requested_runner_tag: 'gpu'
       is_requested_runner_a_gpu_runner: true
+    # Output : needs.check-runner.outputs.runner_tag -> "gpu" or "ubuntu-latest" (runner github)
+    #          needs.check-runner.outputs.is_a_gpu_runner -> "true" if "gpu" is available, "false" with "ubuntu-latest"
 
   tests:
     name: 'Build and Test'
@@ -48,6 +56,11 @@ jobs:
           echo "SOURCE_DIR=${GITHUB_WORKSPACE}/src" >> $GITHUB_ENV
           echo "BUILD_DIR=${GITHUB_WORKSPACE}/build" >> $GITHUB_ENV
           echo "CT_RESULT_DIR=${GITHUB_WORKSPACE}/test" >> $GITHUB_ENV
+
+      - name: Configure environment
+        shell: bash
+        run: |
+          source /root/scripts/default_alternatives.sh
 
       - name: Checkout repo
         uses: actions/checkout@v6

--- a/.github/workflows/soildynamics.yml
+++ b/.github/workflows/soildynamics.yml
@@ -25,11 +25,21 @@ env:
   OMPI_MCA_rmaps_base_oversubscribe: 1
 
 jobs:
+  check-runner:
+    name: 'Check runner'
+    uses: 'arcaneframework/gh_actions/.github/workflows/check_runner.yml@v3'
+    secrets: inherit
+    with:
+      requested_runner_tag: 'gpu'
+      is_requested_runner_a_gpu_runner: true
+
   tests:
     name: 'Build and Test'
-    runs-on: ubuntu-latest
+    needs: check-runner
+    runs-on: ${{ needs.check-runner.outputs.runner_tag }}
     container:
       image: ghcr.io/arcaneframework/arcane_ubuntu-2404:gcc-14_full_check_latest
+      options: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true', '--runtime nvidia --gpus all', '') }}
 
     steps:
       - name: Define environment paths
@@ -40,7 +50,7 @@ jobs:
           echo "CT_RESULT_DIR=${GITHUB_WORKSPACE}/test" >> $GITHUB_ENV
 
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: ${{ env.SOURCE_DIR }}
 
@@ -64,7 +74,7 @@ jobs:
           ctest --test-dir ${{ env.BUILD_DIR }} --output-junit ${{ env.CT_RESULT_DIR }}/results.xml ${{ env.CT_OPTS }} -R '\[${{ env.MODULE }}\]'
 
       - name: Upload test artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: tests-${{ env.MODULE_DIR }}-artifact

--- a/.github/workflows/soildynamics.yml
+++ b/.github/workflows/soildynamics.yml
@@ -46,7 +46,9 @@ jobs:
     needs: check-runner
     runs-on: ${{ needs.check-runner.outputs.runner_tag }}
     container:
-      image: ghcr.io/arcaneframework/arcane_ubuntu-2604:full_check_latest
+      image: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true',
+        'ghcr.io/arcaneframework/arcane_ubuntu-2604:cuda_full_check_latest',
+        'ghcr.io/arcaneframework/arcane_ubuntu-2604:full_check_latest') }}
       options: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true', '--runtime nvidia --gpus all', '') }}
 
     steps:

--- a/.github/workflows/soildynamics.yml
+++ b/.github/workflows/soildynamics.yml
@@ -38,7 +38,7 @@ jobs:
     needs: check-runner
     runs-on: ${{ needs.check-runner.outputs.runner_tag }}
     container:
-      image: ghcr.io/arcaneframework/arcane_ubuntu-2404:gcc-14_full_check_latest
+      image: ghcr.io/arcaneframework/arcane_ubuntu-2604:full_check_latest
       options: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true', '--runtime nvidia --gpus all', '') }}
 
     steps:

--- a/.github/workflows/soildynamics.yml
+++ b/.github/workflows/soildynamics.yml
@@ -83,6 +83,7 @@ jobs:
       - name: Test
         shell: bash
         run: |
+          [ -f /root/scripts/config_env.sh ] && source /root/scripts/config_env.sh
           mkdir -p ${{ env.CT_RESULT_DIR }}
           ctest --test-dir ${{ env.BUILD_DIR }} --output-junit ${{ env.CT_RESULT_DIR }}/results.xml ${{ env.CT_OPTS }} -R '\[${{ env.MODULE }}\]'
 
@@ -90,6 +91,6 @@ jobs:
         uses: actions/upload-artifact@v7
         if: failure()
         with:
-          name: tests-${{ env.MODULE_DIR }}-artifact
+          name: tests-${{ env.MODULE }}-artifact
           path: ${{ env.CT_RESULT_DIR }}
           retention-days: 7

--- a/.github/workflows/soildynamics.yml
+++ b/.github/workflows/soildynamics.yml
@@ -11,6 +11,10 @@ on:
       - modules/soildynamics/**
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   MODULE_DIR: 'modules/soildynamics'
 
@@ -23,8 +27,10 @@ env:
   OMPI_ALLOW_RUN_AS_ROOT: 1
   OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
   OMPI_MCA_rmaps_base_oversubscribe: 1
+  PRTE_MCA_rmaps_default_mapping_policy: :oversubscribe
 
 jobs:
+  # Check if the self-hosted runner with tag "gpu" is available.
   check-runner:
     name: 'Check runner'
     uses: 'arcaneframework/gh_actions/.github/workflows/check_runner.yml@v3'
@@ -32,6 +38,8 @@ jobs:
     with:
       requested_runner_tag: 'gpu'
       is_requested_runner_a_gpu_runner: true
+    # Output : needs.check-runner.outputs.runner_tag -> "gpu" or "ubuntu-latest" (runner github)
+    #          needs.check-runner.outputs.is_a_gpu_runner -> "true" if "gpu" is available, "false" with "ubuntu-latest"
 
   tests:
     name: 'Build and Test'
@@ -48,6 +56,11 @@ jobs:
           echo "SOURCE_DIR=${GITHUB_WORKSPACE}/src" >> $GITHUB_ENV
           echo "BUILD_DIR=${GITHUB_WORKSPACE}/build" >> $GITHUB_ENV
           echo "CT_RESULT_DIR=${GITHUB_WORKSPACE}/test" >> $GITHUB_ENV
+
+      - name: Configure environment
+        shell: bash
+        run: |
+          source /root/scripts/default_alternatives.sh
 
       - name: Checkout repo
         uses: actions/checkout@v6

--- a/.github/workflows/testlab.yml
+++ b/.github/workflows/testlab.yml
@@ -11,6 +11,10 @@ on:
       - modules/testlab/**
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   MODULE_DIR: 'modules/testlab'
 
@@ -23,8 +27,10 @@ env:
   OMPI_ALLOW_RUN_AS_ROOT: 1
   OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
   OMPI_MCA_rmaps_base_oversubscribe: 1
+  PRTE_MCA_rmaps_default_mapping_policy: :oversubscribe
 
 jobs:
+  # Check if the self-hosted runner with tag "gpu" is available.
   check-runner:
     name: 'Check runner'
     uses: 'arcaneframework/gh_actions/.github/workflows/check_runner.yml@v3'
@@ -32,6 +38,8 @@ jobs:
     with:
       requested_runner_tag: 'gpu'
       is_requested_runner_a_gpu_runner: true
+    # Output : needs.check-runner.outputs.runner_tag -> "gpu" or "ubuntu-latest" (runner github)
+    #          needs.check-runner.outputs.is_a_gpu_runner -> "true" if "gpu" is available, "false" with "ubuntu-latest"
 
   tests:
     name: 'Build and Test'
@@ -48,6 +56,11 @@ jobs:
           echo "SOURCE_DIR=${GITHUB_WORKSPACE}/src" >> $GITHUB_ENV
           echo "BUILD_DIR=${GITHUB_WORKSPACE}/build" >> $GITHUB_ENV
           echo "CT_RESULT_DIR=${GITHUB_WORKSPACE}/test" >> $GITHUB_ENV
+
+      - name: Configure environment
+        shell: bash
+        run: |
+          source /root/scripts/default_alternatives.sh
 
       - name: Checkout repo
         uses: actions/checkout@v6

--- a/.github/workflows/testlab.yml
+++ b/.github/workflows/testlab.yml
@@ -25,11 +25,21 @@ env:
   OMPI_MCA_rmaps_base_oversubscribe: 1
 
 jobs:
+  check-runner:
+    name: 'Check runner'
+    uses: 'arcaneframework/gh_actions/.github/workflows/check_runner.yml@v3'
+    secrets: inherit
+    with:
+      requested_runner_tag: 'gpu'
+      is_requested_runner_a_gpu_runner: true
+
   tests:
     name: 'Build and Test'
-    runs-on: ubuntu-latest
+    needs: check-runner
+    runs-on: ${{ needs.check-runner.outputs.runner_tag }}
     container:
       image: ghcr.io/arcaneframework/arcane_ubuntu-2404:gcc-14_full_check_latest
+      options: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true', '--runtime nvidia --gpus all', '') }}
 
     steps:
       - name: Define environment paths
@@ -40,7 +50,7 @@ jobs:
           echo "CT_RESULT_DIR=${GITHUB_WORKSPACE}/test" >> $GITHUB_ENV
 
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: ${{ env.SOURCE_DIR }}
 
@@ -64,7 +74,7 @@ jobs:
           ctest --test-dir ${{ env.BUILD_DIR }} --output-junit ${{ env.CT_RESULT_DIR }}/results.xml ${{ env.CT_OPTS }} -R '\[${{ env.MODULE }}\]'
 
       - name: Upload test artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: tests-${{ env.MODULE_DIR }}-artifact

--- a/.github/workflows/testlab.yml
+++ b/.github/workflows/testlab.yml
@@ -46,7 +46,9 @@ jobs:
     needs: check-runner
     runs-on: ${{ needs.check-runner.outputs.runner_tag }}
     container:
-      image: ghcr.io/arcaneframework/arcane_ubuntu-2604:full_check_latest
+      image: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true',
+        'ghcr.io/arcaneframework/arcane_ubuntu-2604:cuda_full_check_latest',
+        'ghcr.io/arcaneframework/arcane_ubuntu-2604:full_check_latest') }}
       options: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true', '--runtime nvidia --gpus all', '') }}
 
     steps:

--- a/.github/workflows/testlab.yml
+++ b/.github/workflows/testlab.yml
@@ -38,7 +38,7 @@ jobs:
     needs: check-runner
     runs-on: ${{ needs.check-runner.outputs.runner_tag }}
     container:
-      image: ghcr.io/arcaneframework/arcane_ubuntu-2404:gcc-14_full_check_latest
+      image: ghcr.io/arcaneframework/arcane_ubuntu-2604:full_check_latest
       options: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true', '--runtime nvidia --gpus all', '') }}
 
     steps:

--- a/.github/workflows/testlab.yml
+++ b/.github/workflows/testlab.yml
@@ -83,6 +83,7 @@ jobs:
       - name: Test
         shell: bash
         run: |
+          [ -f /root/scripts/config_env.sh ] && source /root/scripts/config_env.sh
           mkdir -p ${{ env.CT_RESULT_DIR }}
           ctest --test-dir ${{ env.BUILD_DIR }} --output-junit ${{ env.CT_RESULT_DIR }}/results.xml ${{ env.CT_OPTS }} -R '\[${{ env.MODULE }}\]'
 
@@ -90,6 +91,6 @@ jobs:
         uses: actions/upload-artifact@v7
         if: failure()
         with:
-          name: tests-${{ env.MODULE_DIR }}-artifact
+          name: tests-${{ env.MODULE }}-artifact
           path: ${{ env.CT_RESULT_DIR }}
           retention-days: 7

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
     needs: check-runner
     runs-on: ${{ needs.check-runner.outputs.runner_tag }}
     container:
-      image: ghcr.io/arcaneframework/arcane_ubuntu-2404:gcc-14_full_check_latest
+      image: ghcr.io/arcaneframework/arcane_ubuntu-2604:full_check_latest
       options: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true', '--runtime nvidia --gpus all', '') }}
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,10 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   # CTest
   CT_OPTS: "--timeout 300 --output-on-failure"
@@ -15,8 +19,10 @@ env:
   OMPI_ALLOW_RUN_AS_ROOT: 1
   OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
   OMPI_MCA_rmaps_base_oversubscribe: 1
+  PRTE_MCA_rmaps_default_mapping_policy: :oversubscribe
 
 jobs:
+  # Check if the self-hosted runner with tag "gpu" is available.
   check-runner:
     name: 'Check runner'
     uses: 'arcaneframework/gh_actions/.github/workflows/check_runner.yml@v3'
@@ -32,6 +38,8 @@ jobs:
     container:
       image: ghcr.io/arcaneframework/arcane_ubuntu-2604:full_check_latest
       options: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true', '--runtime nvidia --gpus all', '') }}
+    # Output : needs.check-runner.outputs.runner_tag -> "gpu" or "ubuntu-latest" (runner github)
+    #          needs.check-runner.outputs.is_a_gpu_runner -> "true" if "gpu" is available, "false" with "ubuntu-latest"
 
     steps:
       - name: Define environment paths
@@ -40,6 +48,11 @@ jobs:
           echo "SOURCE_DIR=${GITHUB_WORKSPACE}/src" >> $GITHUB_ENV
           echo "BUILD_DIR=${GITHUB_WORKSPACE}/build" >> $GITHUB_ENV
           echo "CT_RESULT_DIR=${GITHUB_WORKSPACE}/test" >> $GITHUB_ENV
+
+      - name: Configure environment
+        shell: bash
+        run: |
+          source /root/scripts/default_alternatives.sh
 
       - name: Checkout repo
         uses: actions/checkout@v6

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,9 @@ jobs:
     needs: check-runner
     runs-on: ${{ needs.check-runner.outputs.runner_tag }}
     container:
-      image: ghcr.io/arcaneframework/arcane_ubuntu-2604:full_check_latest
+      image: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true',
+        'ghcr.io/arcaneframework/arcane_ubuntu-2604:cuda_full_check_latest',
+        'ghcr.io/arcaneframework/arcane_ubuntu-2604:full_check_latest') }}
       options: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true', '--runtime nvidia --gpus all', '') }}
     # Output : needs.check-runner.outputs.runner_tag -> "gpu" or "ubuntu-latest" (runner github)
     #          needs.check-runner.outputs.is_a_gpu_runner -> "true" if "gpu" is available, "false" with "ubuntu-latest"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,6 +75,7 @@ jobs:
       - name: Test
         shell: bash
         run: |
+          [ -f /root/scripts/config_env.sh ] && source /root/scripts/config_env.sh
           mkdir -p ${{ env.CT_RESULT_DIR }}
           ctest --test-dir ${{ env.BUILD_DIR }} --output-junit ${{ env.CT_RESULT_DIR }}/results.xml ${{ env.CT_OPTS }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,11 +17,21 @@ env:
   OMPI_MCA_rmaps_base_oversubscribe: 1
 
 jobs:
+  check-runner:
+    name: 'Check runner'
+    uses: 'arcaneframework/gh_actions/.github/workflows/check_runner.yml@v3'
+    secrets: inherit
+    with:
+      requested_runner_tag: 'gpu'
+      is_requested_runner_a_gpu_runner: true
+
   tests:
     name: 'Build and Test'
-    runs-on: ubuntu-latest
+    needs: check-runner
+    runs-on: ${{ needs.check-runner.outputs.runner_tag }}
     container:
       image: ghcr.io/arcaneframework/arcane_ubuntu-2404:gcc-14_full_check_latest
+      options: ${{ case(needs.check-runner.outputs.is_a_gpu_runner == 'true', '--runtime nvidia --gpus all', '') }}
 
     steps:
       - name: Define environment paths
@@ -32,7 +42,7 @@ jobs:
           echo "CT_RESULT_DIR=${GITHUB_WORKSPACE}/test" >> $GITHUB_ENV
 
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: ${{ env.SOURCE_DIR }}
 
@@ -56,7 +66,7 @@ jobs:
           ctest --test-dir ${{ env.BUILD_DIR }} --output-junit ${{ env.CT_RESULT_DIR }}/results.xml ${{ env.CT_OPTS }}
 
       - name: Upload test artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: test-all-modules-artifact


### PR DESCRIPTION
(Self-hosted runner disabled via repository environment variable)
- `concurrency` part to cancel workflows on new PR pushes
- `check-runner` job to verify self-hosted runners availability
- `Configure environment` job to set up compilers before building
- `source /root/scripts/config_env.sh` step to apply Ubuntu 26.04 OpenMPI fixes
- Upload test results to Codecov.