### PR TITLE
Fix PetscLinearSystem

### DIFF
--- a/femutils/CsrDoFLinearSystemImpl.cc
+++ b/femutils/CsrDoFLinearSystemImpl.cc
@@ -108,7 +108,7 @@ _applyRowColumnEliminationOnMatrix()
     bool is_row_elimination = (row_elimination_info == ELIMINATE_ROW) || (row_elimination_info == ELIMINATE_ROW_COLUMN);
     for (CsrRowColumnIndex csr_index : csr_view.rowRange(dof_row)) {
       Int32 column_index = csr_view.column(csr_index);
-      if (column_index > 0) {
+      if (column_index >= 0) {
         DoFLocalId dof_column(column_index);
         auto column_elimination_info = in_elimination_info[dof_column];
         bool is_column_elimination = (column_elimination_info == ELIMINATE_ROW) || (column_elimination_info == ELIMINATE_ROW_COLUMN);

--- a/femutils/PetscDoFLinearSystem.cc
+++ b/femutils/PetscDoFLinearSystem.cc
@@ -346,6 +346,7 @@ _preallocateMatrix()
 
   PetscCallAbort(mpi_comm, KSPCreate(mpi_comm, &m_petsc_solver_context));
   PetscCallAbort(mpi_comm, KSPSetOperators(m_petsc_solver_context, m_petsc_matrix, m_petsc_matrix));
+  PetscCallAbort(mpi_comm, KSPSetErrorIfNotConverged(m_petsc_solver_context, PETSC_TRUE)); // To catch errors if the solver does not converge
   PetscCallAbort(mpi_comm, KSPSetFromOptions(m_petsc_solver_context));
 }
 

--- a/femutils/PetscDoFLinearSystem.cc
+++ b/femutils/PetscDoFLinearSystem.cc
@@ -222,9 +222,6 @@ _handleParameters(IParallelMng* pm)
   }
 
   PetscBool set;
-  PETSC_OPTION(Real, "-ksp_rtol", m_ksp_rtol)
-  PETSC_OPTION(Real, "-ksp_atol", m_ksp_atol)
-  PETSC_OPTION(Int, "-ksp_max_it", m_ksp_max_it)
   PETSC_OPTION_STRING("-ksp_type", m_ksp_type)
   PETSC_OPTION_STRING("-pc_type", m_pc_type)
   PETSC_OPTION_STRING("-mat_type", m_mat_type)
@@ -344,8 +341,10 @@ _preallocateMatrix()
   PetscCallAbort(mpi_comm, MatAssemblyBegin(m_petsc_matrix, MAT_FINAL_ASSEMBLY));
   PetscCallAbort(mpi_comm, MatAssemblyEnd(m_petsc_matrix, MAT_FINAL_ASSEMBLY));
 
+  // Todo: seperate function for KSP creation and setting operators, tolerances, etc.
   PetscCallAbort(mpi_comm, KSPCreate(mpi_comm, &m_petsc_solver_context));
   PetscCallAbort(mpi_comm, KSPSetOperators(m_petsc_solver_context, m_petsc_matrix, m_petsc_matrix));
+  PetscCallAbort(mpi_comm, KSPSetTolerances(m_petsc_solver_context, m_ksp_rtol, m_ksp_atol, PETSC_DEFAULT, m_ksp_max_it)); // Todo: add dtol in ArcaneFEM and replace PETSC_DEFAULT
   PetscCallAbort(mpi_comm, KSPSetErrorIfNotConverged(m_petsc_solver_context, PETSC_TRUE)); // To catch errors if the solver does not converge
   PetscCallAbort(mpi_comm, KSPSetFromOptions(m_petsc_solver_context));
 }

--- a/modules/elastodynamics/CMakeLists.txt
+++ b/modules/elastodynamics/CMakeLists.txt
@@ -242,7 +242,7 @@ if (FEMUTILS_HAS_SOLVER_BACKEND_PETSC)
   set(SOLVER_PETSC_DIRECT_CG
     -A,//fem/linear-system/@name=PetscLinearSystem
     -A,//fem/linear-system/solver=cg
-    -A,//fem/linear-system/atol=1e-9
+    -A,//fem/linear-system/atol=1e-12
     -A,//fem/linear-system/rtol=0)
 
   arcanefem_add_full_test(NAME 2D_bar_petsc-direct_bsr

--- a/modules/soildynamics/CMakeLists.txt
+++ b/modules/soildynamics/CMakeLists.txt
@@ -86,7 +86,7 @@ if (FEMUTILS_HAS_SOLVER_BACKEND_PETSC)
   set(SOLVER_PETSC_DIRECT_CG
     -A,//fem/linear-system/@name=PetscLinearSystem
     -A,//fem/linear-system/solver=cg
-    -A,//fem/linear-system/atol=1e-9
+    -A,//fem/linear-system/atol=1e-14
     -A,//fem/linear-system/rtol=0)
 
   arcanefem_add_full_test(NAME 2d_semi-circle_const_traction_pointbc_petsc-direct_bsr


### PR DESCRIPTION
- Now error is raised if Linear system is not converged in max iterations used 
https://petsc.org/release/manualpages/KSP/KSPSetErrorIfNotConverged/

- This exposed other bug. The string to real value conversion used before in `handleparamter()` was causing small values e.g 1e-15 ---> 0.000 . As max iterations was not considered error the solver would max out in most cases. 

- Exposed bug on Row/Column elimination, column 0 was not being included for emilination 